### PR TITLE
fix(ToolsStrip): Fix offset in oblique visibility icon

### DIFF
--- a/girdermedviewer/app/components.py
+++ b/girdermedviewer/app/components.py
@@ -252,6 +252,7 @@ class ToolsStrip(html.Div):
             classes="bg-grey-darken-4 d-flex flex-column align-center",
             **kwargs,
         )
+        client.Style(".v-input--selection-controls__input {margin-right: 0px!important}")
 
         with self:
             VCheckbox(


### PR DESCRIPTION
VCheckbox icon has a right margin in order to prevent text to be too close from the icon. When there is no text, there is no need for such margin.
Maybe the query selector could be improved.