### PR TITLE
Rendering fixes

### DIFF
--- a/girdermedviewer/app/__init__.py
+++ b/girdermedviewer/app/__init__.py
@@ -1,5 +1,5 @@
 from .__main__ import main
 
 __all__ = [
-    "__main__",
+    "main",
 ]

--- a/girdermedviewer/app/core.py
+++ b/girdermedviewer/app/core.py
@@ -4,7 +4,7 @@ import sys
 from trame.app import TrameApp
 from trame_server import Server
 
-from girdermedviewer.app.widgets import AppLayout, AppLogic, AppUI
+from .widgets import AppLayout, AppLogic, AppUI
 
 
 class MedViewerApp(TrameApp):

--- a/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
@@ -6,7 +6,7 @@ from trame_server.core import Server
 
 from ....utils import DataArray, MeshColoringMode, debounce, supported_mesh_extensions
 from ...vtk.views_logic import ViewsLogic
-from ..objects.mesh_object_logic import MeshDisplay, MeshObjectLogic
+from ..objects.mesh_object_logic import MeshObjectLogic
 from .object_handler import ObjectHandler
 
 logger = logging.getLogger(__name__)
@@ -16,43 +16,47 @@ class MeshDisplayHandler:
     def __init__(self, views_logic: ViewsLogic):
         self.views_logic = views_logic
 
-    def update_visibility(self, mesh_id: str) -> Callable:
-        @debounce(0.05)
+    def update_visibility(self, mesh_logic: MeshObjectLogic) -> Callable:
         def _update_visibility(visible: bool) -> None:
             for view in self.views_logic.views:
-                modified = view.mesh_handler.set_mesh_visibility(mesh_id, visible)
+                modified = view.mesh_handler.set_mesh_visibility(mesh_logic._id, visible)
                 if modified:
                     view.update()
 
         return _update_visibility
 
-    def update_opacity(self, mesh_id: str) -> Callable:
+    def update_opacity(self, mesh_logic: MeshObjectLogic) -> Callable:
         @debounce(0.05)
         def _update_opacity(opacity: float) -> None:
+            if opacity < 0 or not mesh_logic.is_visible:
+                return
             for view in self.views_logic.views:
-                modified = view.mesh_handler.set_mesh_opacity(mesh_id, opacity)
+                modified = view.mesh_handler.set_mesh_opacity(mesh_logic._id, opacity)
                 if modified:
                     view.update()
 
         return _update_opacity
 
-    def update_solid_coloring(self, mesh_id: str) -> Callable:
+    def update_solid_coloring(self, mesh_logic: MeshObjectLogic) -> Callable:
         @debounce(0.05)
         def _update_solid_coloring(color: str) -> None:
+            if not mesh_logic.is_visible:
+                return
             for view in self.views_logic.views:
-                modified = view.mesh_handler.set_mesh_solid_color(mesh_id, color)
+                modified = view.mesh_handler.set_mesh_solid_color(mesh_logic._id, color)
                 if modified:
                     view.update()
 
         return _update_solid_coloring
 
-    def update_array_coloring(self, mesh_id: str, mesh_display: MeshDisplay) -> Callable:
-        @debounce(0.05)
+    def update_array_coloring(self, mesh_logic: MeshObjectLogic) -> Callable:
         def _update_array_coloring(name: str, is_inverted: bool, scalar_range: list[float]) -> None:
-            active_array = get_instance(mesh_display.active_array_id)
+            if not mesh_logic.is_visible:
+                return
+            active_array = get_instance(mesh_logic.display.active_array_id)
             for view in self.views_logic.views:
                 modified = view.mesh_handler.set_mesh_array_color(
-                    mesh_id,
+                    mesh_logic._id,
                     active_array,
                     name,
                     is_inverted,
@@ -63,16 +67,17 @@ class MeshDisplayHandler:
 
         return _update_array_coloring
 
-    def update_active_array(self, mesh_id: str, mesh_display: MeshDisplay) -> Callable:
-        @debounce(0.05)
+    def update_active_array(self, mesh_logic: MeshObjectLogic) -> Callable:
         def _update_active_array(active_array_id: str) -> None:
+            if not mesh_logic.is_visible:
+                return
             active_array = get_instance(active_array_id)
             assert isinstance(active_array, DataArray)
             if active_array.coloring_mode == MeshColoringMode.SOLID:
-                self.update_solid_coloring(mesh_id)(mesh_display.solid_color)
+                self.update_solid_coloring(mesh_logic)(mesh_logic.display.solid_color)
 
             elif active_array.coloring_mode == MeshColoringMode.ARRAY:
-                mesh_display.array_color.array_range = active_array.array_min_max
+                mesh_logic.display.array_color.array_range = active_array.array_min_max
 
         return _update_active_array
 
@@ -80,23 +85,21 @@ class MeshDisplayHandler:
 class MeshHandler(ObjectHandler):
     def __init__(self, server: Server, views_logic: ViewsLogic):
         super().__init__(server, views_logic)
-        self.display_handler = MeshDisplayHandler(views_logic)
+        self._display_handler = MeshDisplayHandler(views_logic)
 
     @property
     def supported_extensions(self) -> tuple[str]:
         return supported_mesh_extensions()
 
     def _connect_mesh_logic_to_display_handler(self, mesh_logic: MeshObjectLogic):
-        mesh_logic.display.watch(("opacity",), self.display_handler.update_opacity(mesh_logic._id))
-        mesh_logic.display.watch(
-            ("active_array_id",), self.display_handler.update_active_array(mesh_logic._id, mesh_logic.display)
-        )
-        mesh_logic.display.watch(("solid_color",), self.display_handler.update_solid_coloring(mesh_logic._id))
+        mesh_logic.display.watch(("opacity",), self._display_handler.update_opacity(mesh_logic))
+        mesh_logic.display.watch(("active_array_id",), self._display_handler.update_active_array(mesh_logic))
+        mesh_logic.display.watch(("solid_color",), self._display_handler.update_solid_coloring(mesh_logic))
         mesh_logic.display.array_color.watch(
             ("name", "is_inverted", "array_range"),
-            self.display_handler.update_array_coloring(mesh_logic._id, mesh_logic.display),
+            self._display_handler.update_array_coloring(mesh_logic),
         )
-        mesh_logic.scene_object.watch(("is_visible",), self.display_handler.update_visibility(mesh_logic._id))
+        mesh_logic.scene_object.watch(("is_visible",), self._display_handler.update_visibility(mesh_logic))
 
     def add_object_to_views(self, mesh_logic: MeshObjectLogic) -> None:
         self.object_logics[mesh_logic._id] = mesh_logic

--- a/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
@@ -39,10 +39,8 @@ class MeshDisplayHandler:
     def update_solid_coloring(self, mesh_id: str) -> Callable:
         @debounce(0.05)
         def _update_solid_coloring(color: str) -> None:
-            hex = color.lstrip("#")
-            color_tuple = tuple(float(int(hex[i : i + 2], 16)) / 255.0 for i in (0, 2, 4))
             for view in self.views_logic.views:
-                modified = view.mesh_handler.set_mesh_solid_color(mesh_id, color_tuple)
+                modified = view.mesh_handler.set_mesh_solid_color(mesh_id, color)
                 if modified:
                     view.update()
 
@@ -103,7 +101,7 @@ class MeshHandler(ObjectHandler):
     def add_object_to_views(self, mesh_logic: MeshObjectLogic) -> None:
         self.object_logics[mesh_logic._id] = mesh_logic
         self._connect_mesh_logic_to_display_handler(mesh_logic)
-        self.views_logic.add_mesh(mesh_logic._id, mesh_logic.object_data)
+        self.views_logic.add_mesh(mesh_logic._id, mesh_logic.object_data, mesh_logic.display)
 
     def remove_object_from_views(self, mesh_logic: MeshObjectLogic) -> None:
         mesh_logic.display.clear_watchers()

--- a/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
@@ -50,6 +50,7 @@ class SegmentationDisplayHandler:
                 return
             for view in self.views_logic.slice_views:
                 view.volume_handler.set_segment_color(seg_logic._id, segment_id, color)
+                view.update()
 
         return _update_segment_color
 
@@ -59,6 +60,7 @@ class SegmentationDisplayHandler:
                 return
             for view in self.views_logic.slice_views:
                 view.volume_handler.set_segment_visibility(seg_logic._id, segment_id, visible)
+                view.update()
 
         return _update_segment_visbility
 

--- a/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
@@ -77,7 +77,11 @@ class SegmentationHandler(ObjectHandler):
         self._connect_labelmap_to_display_handler(seg_filter_logic)
 
         self.views_logic.add_volume(
-            seg_filter_logic._id, seg_filter_logic.object_data, seg_filter_logic.layer, SceneObjectSubtype.LABELMAP
+            seg_filter_logic._id,
+            seg_filter_logic.object_data,
+            seg_filter_logic.display,
+            seg_filter_logic.layer,
+            SceneObjectSubtype.LABELMAP,
         )
 
     def remove_object_from_views(self, seg_filter_logic: SegmentationFilterLogic) -> None:

--- a/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
@@ -49,8 +49,9 @@ class SegmentationDisplayHandler:
             if not seg_logic.is_visible:
                 return
             for view in self.views_logic.slice_views:
-                view.volume_handler.set_segment_color(seg_logic._id, segment_id, color)
-                view.update()
+                modified = view.volume_handler.set_segment_color(seg_logic._id, segment_id, color)
+                if modified:
+                    view.update()
 
         return _update_segment_color
 
@@ -59,8 +60,9 @@ class SegmentationDisplayHandler:
             if not seg_logic.is_visible:
                 return
             for view in self.views_logic.slice_views:
-                view.volume_handler.set_segment_visibility(seg_logic._id, segment_id, visible)
-                view.update()
+                modified = view.volume_handler.set_segment_visibility(seg_logic._id, segment_id, visible)
+                if modified:
+                    view.update()
 
         return _update_segment_visbility
 

--- a/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Callable
 
 from trame_dataclass.v2 import get_instance
 from trame_server.core import Server
@@ -22,38 +23,42 @@ class SegmentationDisplayHandler:
     def __init__(self, views_logic: ViewsLogic):
         self.views_logic = views_logic
 
-    def update_opacity(self, labelmap_id: str):
-        @debounce(0.05)
-        def _update_opacity(opacity: float) -> None:
-            if opacity < 0:
-                return
-            for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_volume_opacity(labelmap_id, opacity)
-                if modified:
-                    view.update()
-
-        return _update_opacity
-
-    def update_visibility(self, labelmap_id: str):
+    def update_visibility(self, seg_logic: SegmentationFilterLogic) -> Callable:
         def _update_visibility(visible: bool):
             for view in self.views_logic.views:
-                modified = view.volume_handler.set_volume_visibility(labelmap_id, visible)
+                modified = view.volume_handler.set_volume_visibility(seg_logic._id, visible)
                 if modified:
                     view.update()
 
         return _update_visibility
 
-    def update_segment_color(self, labelmap_id: str, segment_id: int):
-        def _update_segment_color(color: str) -> None:
+    def update_opacity(self, seg_logic: SegmentationFilterLogic) -> Callable:
+        @debounce(0.05)
+        def _update_opacity(opacity: float) -> None:
+            if opacity < 0 or not seg_logic.is_visible:
+                return
             for view in self.views_logic.slice_views:
-                view.volume_handler.set_segment_color(labelmap_id, segment_id, color)
+                modified = view.volume_handler.set_volume_opacity(seg_logic._id, opacity)
+                if modified:
+                    view.update()
+
+        return _update_opacity
+
+    def update_segment_color(self, seg_logic: SegmentationFilterLogic, segment_id: int) -> Callable:
+        def _update_segment_color(color: str) -> None:
+            if not seg_logic.is_visible:
+                return
+            for view in self.views_logic.slice_views:
+                view.volume_handler.set_segment_color(seg_logic._id, segment_id, color)
 
         return _update_segment_color
 
-    def update_segment_visibility(self, labelmap_id: str, segment_id: int):
+    def update_segment_visibility(self, seg_logic: SegmentationFilterLogic, segment_id: int):
         def _update_segment_visbility(visible: bool) -> None:
+            if not seg_logic.is_visible:
+                return
             for view in self.views_logic.slice_views:
-                view.volume_handler.set_segment_visibility(labelmap_id, segment_id, visible)
+                view.volume_handler.set_segment_visibility(seg_logic._id, segment_id, visible)
 
         return _update_segment_visbility
 
@@ -61,7 +66,7 @@ class SegmentationDisplayHandler:
 class SegmentationHandler(ObjectHandler):
     def __init__(self, server: Server, views_logic: ViewsLogic):
         super().__init__(server, views_logic)
-        self.display_handler = SegmentationDisplayHandler(views_logic)
+        self._display_handler = SegmentationDisplayHandler(views_logic)
 
     @property
     def supported_extensions(self) -> tuple[str]:
@@ -100,10 +105,8 @@ class SegmentationHandler(ObjectHandler):
         seg_filter_logic.scene_object.is_visible = visible
 
     def _connect_labelmap_to_display_handler(self, seg_filter_logic: SegmentationFilterLogic):
-        seg_filter_logic.display.watch(("opacity",), self.display_handler.update_opacity(seg_filter_logic._id))
-        seg_filter_logic.scene_object.watch(
-            ("is_visible",), self.display_handler.update_visibility(seg_filter_logic._id)
-        )
+        seg_filter_logic.display.watch(("opacity",), self._display_handler.update_opacity(seg_filter_logic))
+        seg_filter_logic.scene_object.watch(("is_visible",), self._display_handler.update_visibility(seg_filter_logic))
 
     def select_segment_in_labelmap(
         self, seg_filter_logic: SegmentationFilterLogic | None, segment_id: str | None = None
@@ -125,11 +128,9 @@ class SegmentationHandler(ObjectHandler):
 
     def add_segment_to_labelmap(self, seg_filter_logic: SegmentationFilterLogic) -> None:
         new_segment = seg_filter_logic.create_segment()
+        new_segment.watch(("color",), self._display_handler.update_segment_color(seg_filter_logic, new_segment.value))
         new_segment.watch(
-            ("color",), self.display_handler.update_segment_color(seg_filter_logic._id, new_segment.value)
-        )
-        new_segment.watch(
-            ("is_visible",), self.display_handler.update_segment_visibility(seg_filter_logic._id, new_segment.value)
+            ("is_visible",), self._display_handler.update_segment_visibility(seg_filter_logic, new_segment.value)
         )
         self.select_segment_in_labelmap(seg_filter_logic)
 

--- a/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
@@ -16,7 +16,6 @@ class VolumeDisplayHandler:
         self.views_logic = views_logic
 
     def update_threed_visibility(self, volume_id: str) -> Callable:
-        @debounce(0.05)
         def _update_threed_visibility(visible: bool) -> None:
             for view in self.views_logic.threed_views:
                 modified = view.volume_handler.set_volume_visibility(volume_id, visible)
@@ -28,12 +27,6 @@ class VolumeDisplayHandler:
     def update_twod_visibility(self, volume_id: str, visible: bool) -> None:
         for view in self.views_logic.slice_views:
             modified = view.volume_handler.set_volume_visibility(volume_id, visible)
-            if modified:
-                view.update()
-
-    def update_active_primary_volume(self, volume_id: str, image_data) -> None:
-        for view in self.views_logic.slice_views:
-            modified = view.add_volume(volume_id, image_data, VolumeLayer.PRIMARY)
             if modified:
                 view.update()
 
@@ -173,13 +166,15 @@ class VolumeHandler(ObjectHandler):
         volume_logic.display.threed_color.watch(
             ("name", "vr_shift"), self.display_handler.update_threed_coloring(volume_logic._id)
         )
-        volume_logic.display.twod_color.watch(
-            ("name", "is_inverted"), self.display_handler.update_twod_coloring(volume_logic._id)
-        )
-        volume_logic.display.normal_color.watch(
-            ("show_arrows", "sampling", "arrow_length", "arrow_width"),
-            self.display_handler.update_normal_coloring(volume_logic._id),
-        )
+        if volume_logic.display.twod_color is not None:
+            volume_logic.display.twod_color.watch(
+                ("name", "is_inverted"), self.display_handler.update_twod_coloring(volume_logic._id)
+            )
+        elif volume_logic.display.normal_color is not None:
+            volume_logic.display.normal_color.watch(
+                ("show_arrows", "sampling", "arrow_length", "arrow_width"),
+                self.display_handler.update_normal_coloring(volume_logic._id),
+            )
         volume_logic.scene_object.watch(
             ("is_visible",), self.display_handler.update_threed_visibility(volume_logic._id)
         )
@@ -191,7 +186,7 @@ class VolumeHandler(ObjectHandler):
             self._set_active_primary_volume_id(volume_logic._id)
 
         volume_logic.scene_object.is_visible = True
-        self.views_logic.add_volume(volume_logic._id, volume_logic.object_data, layer)
+        self.views_logic.add_volume(volume_logic._id, volume_logic.object_data, volume_logic.display, layer)
 
     def _reload_as_primary_volume(self, volume_logic: VolumeObjectLogic) -> None:
         self.views_logic.remove_volume(volume_logic._id)
@@ -272,8 +267,7 @@ class VolumeHandler(ObjectHandler):
 
     def set_object_visibility(self, volume_logic: VolumeObjectLogic, visible: bool) -> None:
         if self._is_primary_volume(volume_logic._id) and not self._is_active_volume(volume_logic._id) and visible:
-            self._set_active_primary_volume_id(volume_logic._id)
-            self.display_handler.update_active_primary_volume(volume_logic._id, volume_logic.object_data)
+            self._reload_as_primary_volume(volume_logic)
         else:
             volume_logic.scene_object.is_visible = visible
             self.display_handler.update_twod_visibility(volume_logic._id, visible)

--- a/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
@@ -15,39 +15,41 @@ class VolumeDisplayHandler:
     def __init__(self, views_logic: ViewsLogic):
         self.views_logic = views_logic
 
-    def update_threed_visibility(self, volume_id: str) -> Callable:
+    def update_visibility(self, volume_logic: VolumeObjectLogic, visible: bool) -> None:
+        volume_logic.scene_object.is_visible = visible
+        for view in self.views_logic.views:
+            modified = view.volume_handler.set_volume_visibility(volume_logic._id, visible)
+            if modified:
+                view.update()
+
+    def update_threed_visibility(self, volume_logic: VolumeObjectLogic) -> Callable:
         def _update_threed_visibility(visible: bool) -> None:
             for view in self.views_logic.threed_views:
-                modified = view.volume_handler.set_volume_visibility(volume_id, visible)
+                modified = view.volume_handler.set_volume_visibility(volume_logic._id, visible)
                 if modified:
                     view.update()
 
         return _update_threed_visibility
 
-    def update_twod_visibility(self, volume_id: str, visible: bool) -> None:
-        for view in self.views_logic.slice_views:
-            modified = view.volume_handler.set_volume_visibility(volume_id, visible)
-            if modified:
-                view.update()
-
-    def update_opacity(self, volume_id: str) -> Callable:
+    def update_opacity(self, volume_logic: VolumeObjectLogic) -> Callable:
         @debounce(0.05)
         def _update_opacity(opacity: float) -> None:
-            if opacity < 0:
+            if opacity < 0 or not volume_logic.is_visible:
                 return
             for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_volume_opacity(volume_id, opacity)
+                modified = view.volume_handler.set_volume_opacity(volume_logic._id, opacity)
                 if modified:
                     view.update()
 
         return _update_opacity
 
-    def update_threed_coloring(self, volume_id: str) -> Callable:
-        @debounce(0.05)
+    def update_threed_coloring(self, volume_logic: VolumeObjectLogic) -> Callable:
         def _update_threed_coloring(threed_preset_name: str, threed_preset_vr_shift: list[float]) -> None:
+            if not volume_logic.is_visible:
+                return
             for view in self.views_logic.threed_views:
                 modified = view.volume_handler.set_volume_preset(
-                    volume_id,
+                    volume_logic._id,
                     threed_preset_name,
                     threed_preset_vr_shift,
                 )
@@ -56,12 +58,13 @@ class VolumeDisplayHandler:
 
         return _update_threed_coloring
 
-    def update_twod_coloring(self, volume_id: str) -> Callable:
-        @debounce(0.05)
+    def update_twod_coloring(self, volume_logic: VolumeObjectLogic) -> Callable:
         def _update_twod_coloring(twod_preset_name: str, twod_preset_is_inverted: bool) -> None:
+            if not volume_logic.is_visible:
+                return
             for view in self.views_logic.slice_views:
                 modified = view.volume_handler.set_volume_scalar_color_preset(
-                    volume_id,
+                    volume_logic._id,
                     twod_preset_name,
                     twod_preset_is_inverted,
                 )
@@ -70,12 +73,14 @@ class VolumeDisplayHandler:
 
         return _update_twod_coloring
 
-    def update_normal_coloring(self, volume_id: str) -> Callable:
+    def update_normal_coloring(self, volume_logic: VolumeObjectLogic) -> Callable:
         @debounce(0.05)
         def _update_normal_coloring(show_arrows: bool, sampling: int, arrow_length: float, arrow_width: float) -> None:
+            if not volume_logic.is_visible:
+                return
             for view in self.views_logic.slice_views:
                 modified = view.volume_handler.set_volume_normal_color(
-                    volume_id,
+                    volume_logic._id,
                     show_arrows,
                     sampling,
                     arrow_length,
@@ -86,7 +91,7 @@ class VolumeDisplayHandler:
                     view.update()
             for view in self.views_logic.threed_views:
                 modified = view.volume_handler.set_volume_normal_color(
-                    volume_id,
+                    volume_logic._id,
                     show_arrows,
                     sampling,
                     arrow_length,
@@ -97,11 +102,13 @@ class VolumeDisplayHandler:
 
         return _update_normal_coloring
 
-    def update_window_level(self, volume_id: str) -> Callable:
+    def update_window_level(self, volume_logic: VolumeObjectLogic) -> Callable:
         @debounce(0.05)
         def _update_window_level(window_level: list[float]) -> None:
+            if not volume_logic.is_visible:
+                return
             for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_volume_window_level_min_max(volume_id, window_level)
+                modified = view.volume_handler.set_volume_window_level_min_max(volume_logic._id, window_level)
                 if modified:
                     view.update()
 
@@ -111,7 +118,7 @@ class VolumeDisplayHandler:
 class VolumeHandler(ObjectHandler):
     def __init__(self, server: Server, views_logic: ViewsLogic):
         super().__init__(server, views_logic)
-        self.display_handler = VolumeDisplayHandler(self.views_logic)
+        self._display_handler = VolumeDisplayHandler(self.views_logic)
         self.views_logic.window_level_changed.connect(self._update_active_primary_window_level)
 
     @property
@@ -146,12 +153,12 @@ class VolumeHandler(ObjectHandler):
         if self.active_primary_volume_id is not None:
             old_active = self.object_logics.get(self.active_primary_volume_id)
             if old_active is not None:
-                old_active.scene_object.is_visible = False
+                self._display_handler.update_visibility(old_active, False)
 
         self.data.active_primary_volume_id = volume_id
         if self.active_primary_volume_id is not None:
             new_active = self.object_logics.get(self.active_primary_volume_id)
-            new_active.scene_object.is_visible = True
+            self._display_handler.update_visibility(new_active, True)
 
     def _add_to_primary_volumes(self, volume_id: str) -> None:
         if not self._is_primary_volume(volume_id):
@@ -161,23 +168,21 @@ class VolumeHandler(ObjectHandler):
         self.data.primary_volume_ids = [vol_id for vol_id in self.primary_volume_ids if vol_id != volume_id]
 
     def _connect_volume_to_display_handler(self, volume_logic: VolumeObjectLogic):
-        volume_logic.display.watch(("opacity",), self.display_handler.update_opacity(volume_logic._id))
-        volume_logic.display.watch(("window_level",), self.display_handler.update_window_level(volume_logic._id))
+        volume_logic.display.watch(("opacity",), self._display_handler.update_opacity(volume_logic))
+        volume_logic.display.watch(("window_level",), self._display_handler.update_window_level(volume_logic))
         volume_logic.display.threed_color.watch(
-            ("name", "vr_shift"), self.display_handler.update_threed_coloring(volume_logic._id)
+            ("name", "vr_shift"), self._display_handler.update_threed_coloring(volume_logic)
         )
         if volume_logic.display.twod_color is not None:
             volume_logic.display.twod_color.watch(
-                ("name", "is_inverted"), self.display_handler.update_twod_coloring(volume_logic._id)
+                ("name", "is_inverted"), self._display_handler.update_twod_coloring(volume_logic)
             )
         elif volume_logic.display.normal_color is not None:
             volume_logic.display.normal_color.watch(
                 ("show_arrows", "sampling", "arrow_length", "arrow_width"),
-                self.display_handler.update_normal_coloring(volume_logic._id),
+                self._display_handler.update_normal_coloring(volume_logic),
             )
-        volume_logic.scene_object.watch(
-            ("is_visible",), self.display_handler.update_threed_visibility(volume_logic._id)
-        )
+        volume_logic.scene_object.watch(("is_visible",), self._display_handler.update_threed_visibility(volume_logic))
         volume_logic.updated.connect(self.views_logic.update_views)
 
     def _add_volume_to_views(self, volume_logic: VolumeObjectLogic, layer: VolumeLayer) -> None:
@@ -185,7 +190,6 @@ class VolumeHandler(ObjectHandler):
             self._add_to_primary_volumes(volume_logic._id)
             self._set_active_primary_volume_id(volume_logic._id)
 
-        volume_logic.scene_object.is_visible = True
         self.views_logic.add_volume(volume_logic._id, volume_logic.object_data, volume_logic.display, layer)
 
     def _reload_as_primary_volume(self, volume_logic: VolumeObjectLogic) -> None:
@@ -269,5 +273,4 @@ class VolumeHandler(ObjectHandler):
         if self._is_primary_volume(volume_logic._id) and not self._is_active_volume(volume_logic._id) and visible:
             self._reload_as_primary_volume(volume_logic)
         else:
-            volume_logic.scene_object.is_visible = visible
-            self.display_handler.update_twod_visibility(volume_logic._id, visible)
+            self._display_handler.update_visibility(volume_logic, visible)

--- a/girdermedviewer/app/widgets/logic/scene/objects/mesh_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/mesh_object_logic.py
@@ -1,6 +1,6 @@
 import logging
 
-from trame_dataclass.v2 import StateDataModel, Sync
+from trame_dataclass.v2 import StateDataModel, Sync, TypeValidation
 
 from ....utils import (
     DataArray,
@@ -25,7 +25,7 @@ class MeshDisplay(StateDataModel):
     active_array_id = Sync(str)
     solid_color = Sync(str)
     array_color = Sync(ArrayColor, has_dataclass=True)
-    opacity = Sync(float, 1.0)
+    opacity = Sync(float, 1.0, type_checking=TypeValidation.SKIP)
 
 
 class MeshObjectLogic(SceneObjectLogic):

--- a/girdermedviewer/app/widgets/logic/scene/objects/scene_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/scene_object_logic.py
@@ -98,6 +98,10 @@ class SceneObjectLogic(BaseLogic[None]):
         self.input_id = None
         self.soft_input_id = None
 
+    @property
+    def is_visible(self) -> bool:
+        return self.scene_object.is_visible
+
     @abstractmethod
     def load_object_data(self, *args, **kwargs):
         pass

--- a/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
@@ -30,7 +30,7 @@ class VolumeDisplay(StateDataModel):
     threed_color = Sync(ThreeDColor, has_dataclass=True)
     twod_color = Sync(TwoDColor, has_dataclass=True)
     normal_color = Sync(NormalColor, has_dataclass=True)
-    opacity = Sync(float, 1.0, type_checking=TypeValidation.SKIP)
+    opacity = Sync(float, 0.5, type_checking=TypeValidation.SKIP)
 
 
 class BaseVolumeObjectLogic(SceneObjectLogic):
@@ -51,18 +51,17 @@ class VolumeObjectLogic(BaseVolumeObjectLogic):
         super().__init__(*args, **kwargs)
         self.scene_object.object_type = SceneObjectType.VOLUME
         self.display.threed_color = ThreeDColor(self.server)
-        self.display.twod_color = TwoDColor(self.server)
-        self.display.normal_color = NormalColor(self.server)
         self.scalar_range: list[float] = []
 
     def _init_display_properties(self):
         if self.object_data is not None:
             # Init volume type
-            self.scene_object.object_subtype = (
-                SceneObjectSubtype.VECTOR
-                if self.object_data.GetPointData().GetScalars().GetNumberOfComponents() > 1
-                else SceneObjectSubtype.SCALAR
-            )
+            if self.object_data.GetPointData().GetScalars().GetNumberOfComponents() > 1:
+                self.scene_object.object_subtype = SceneObjectSubtype.VECTOR
+                self.display.normal_color = NormalColor(self.server)
+            else:
+                self.scene_object.object_subtype = SceneObjectSubtype.SCALAR
+                self.display.twod_color = TwoDColor(self.server)
 
             self.scalar_range = list(self.object_data.GetScalarRange())
             # Init window level

--- a/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
@@ -30,7 +30,7 @@ class VolumeDisplay(StateDataModel):
     threed_color = Sync(ThreeDColor, has_dataclass=True)
     twod_color = Sync(TwoDColor, has_dataclass=True)
     normal_color = Sync(NormalColor, has_dataclass=True)
-    opacity = Sync(float, 0.5, type_checking=TypeValidation.SKIP)
+    opacity = Sync(float, 0.5, type_checking=TypeValidation.SKIP)  # Used only for secondary volumes
 
 
 class BaseVolumeObjectLogic(SceneObjectLogic):

--- a/girdermedviewer/app/widgets/logic/scene/scene_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/scene_logic.py
@@ -124,7 +124,8 @@ class SceneLogic(BaseLogic[SceneState]):
         if not isinstance(scene_object, SceneObject):
             logger.debug(f"Id {object_id} does not match a SceneObject.")
             return
-        self.object_removed(object_id, scene_object.database_id)
+        if scene_object.database_id is not None:
+            self.object_removed(object_id, scene_object.database_id)
 
     def _get_dependent_objects(self, object_id: str) -> None:
         dependent_objects = []

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
@@ -1,61 +1,19 @@
 import logging
-from collections import defaultdict
-from typing import Any
 
 from vtkmodules.vtkCommonDataModel import vtkPolyData
-from vtkmodules.vtkRenderingCore import vtkRenderer
 
 from ....utils import (
     ColorPresetParser,
     DataArray,
-    get_image_data,
-    remove_prop,
     render_mesh_in_3D,
     render_mesh_in_slice,
     set_mesh_opacity,
     set_mesh_solid_color,
     set_mesh_visibility,
 )
+from .object_handler import ObjectHandler
 
 logger = logging.getLogger(__name__)
-
-
-class ObjectHandler:
-    def __init__(self) -> None:
-        self.object_data = defaultdict(list)
-        self.renderer: vtkRenderer | None = None
-
-    def set_renderer(self, renderer: vtkRenderer) -> None:
-        self.renderer = renderer
-
-    def register_data(self, data_id: str, data: Any) -> None:
-        self.object_data[data_id].append(data)
-
-    def unregister_data(self, data_id, only_data=None, remove=True):
-        for obj in list(self.object_data.get(data_id, [])):
-            if only_data is None or obj == only_data:
-                if remove:
-                    remove_prop(self.renderer, obj)
-                self.object_data[data_id].remove(obj)
-        if len(list(self.object_data.get(data_id, []))) == 0:
-            self.object_data.pop(data_id)
-
-    def get_data(self, data_id):
-        data = self.object_data.get(data_id, [])
-        return data[0] if len(data) else None
-
-    def get_actors(self, data_id):
-        data = [self.object_data[data_id]] if data_id in self.object_data else self.object_data.values()
-        return [obj for objs in data for obj in objs if obj.IsA("vtkActor")]
-
-    def get_image_data(self, data_id):
-        data = [self.object_data[data_id]] if data_id in self.object_data else self.object_data.values()
-        image_data = [get_image_data(obj) for objs in data for obj in objs if get_image_data(obj) is not None]
-        return image_data[0] if len(image_data) > 0 else None
-
-    def get_glyph_actors(self, data_id):
-        data = [self.object_data[data_id]] if data_id in self.object_data else self.object_data.values()
-        return [obj for objs in data for obj in objs if hasattr(obj, 'GetMapper') and obj.GetMapper().IsA("vtkGlyph3DMapper")]
 
 
 class MeshHandler(ObjectHandler):

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
@@ -7,6 +7,7 @@ from ....utils import (
     ColorPresetParser,
     DataArray,
     MeshColoringMode,
+    convert_color_hex_to_normalized_rgb,
     render_mesh_in_3D,
     render_mesh_in_slice,
     set_mesh_opacity,
@@ -64,8 +65,7 @@ class MeshHandler(ObjectHandler):
         return modified
 
     def set_mesh_solid_color(self, data_id: str, color: str) -> bool:
-        hex = color.lstrip("#")
-        color_tuple = tuple(float(int(hex[i : i + 2], 16)) / 255.0 for i in (0, 2, 4))
+        color_tuple = convert_color_hex_to_normalized_rgb(color)
         modified = False
         for actor in self.get_actors(data_id):
             modified = set_mesh_solid_color(actor, color_tuple) or modified

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
@@ -1,16 +1,19 @@
 import logging
 
+from trame_dataclass.v2 import get_instance
 from vtkmodules.vtkCommonDataModel import vtkPolyData
 
 from ....utils import (
     ColorPresetParser,
     DataArray,
+    MeshColoringMode,
     render_mesh_in_3D,
     render_mesh_in_slice,
     set_mesh_opacity,
     set_mesh_solid_color,
     set_mesh_visibility,
 )
+from ...scene.objects.mesh_object_logic import MeshDisplay
 from .object_handler import ObjectHandler
 
 logger = logging.getLogger(__name__)
@@ -21,12 +24,31 @@ class MeshHandler(ObjectHandler):
         super().__init__()
         self.preset_parser = preset_parser
 
+    def apply_mesh_display_properties(self, data_id: str, display_properties: MeshDisplay) -> None:
+        # Set opacity
+        self.set_mesh_opacity(data_id, display_properties.opacity)
+
+        # Set color
+        active_array = get_instance(display_properties.active_array_id)
+        assert isinstance(active_array, DataArray)
+        if active_array.coloring_mode == MeshColoringMode.SOLID:
+            self.set_mesh_solid_color(data_id, display_properties.solid_color)
+
+        elif active_array.coloring_mode == MeshColoringMode.ARRAY:
+            self.set_mesh_array_color(
+                data_id,
+                active_array,
+                display_properties.array_color.name,
+                display_properties.array_color.is_inverted,
+                display_properties.array_color.array_range,
+            )
+
     def add_mesh_in_3D(self, data_id: str, poly_data: vtkPolyData) -> None:
         actor = render_mesh_in_3D(poly_data, self.renderer)
         self.register_data(data_id, actor)
 
-    def add_mesh_in_slice(self, data_id, poly_data: vtkPolyData, orientation) -> None:
-        actor = render_mesh_in_slice(poly_data, orientation.value, self.renderer)
+    def add_mesh_in_slice(self, data_id: str, poly_data: vtkPolyData, orientation: int) -> None:
+        actor = render_mesh_in_slice(poly_data, orientation, self.renderer)
         self.register_data(data_id, actor)
 
     def set_mesh_visibility(self, data_id: str, visible: bool) -> bool:
@@ -41,10 +63,12 @@ class MeshHandler(ObjectHandler):
             modified = set_mesh_opacity(actor, opacity) or modified
         return modified
 
-    def set_mesh_solid_color(self, data_id, color: str) -> bool:
+    def set_mesh_solid_color(self, data_id: str, color: str) -> bool:
+        hex = color.lstrip("#")
+        color_tuple = tuple(float(int(hex[i : i + 2], 16)) / 255.0 for i in (0, 2, 4))
         modified = False
         for actor in self.get_actors(data_id):
-            modified = set_mesh_solid_color(actor, color) or modified
+            modified = set_mesh_solid_color(actor, color_tuple) or modified
         return modified
 
     def set_mesh_array_color(

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
@@ -24,12 +24,18 @@ class ObjectHandler:
         self.object_data[data_id].append(data)
 
     def unregister_data(self, data_id, only_data=None, remove=True):
-        for obj in list(self.object_data.get(data_id, [])):
-            if only_data is None or obj == only_data:
-                if remove:
-                    remove_prop(self.renderer, obj)
-                self.object_data[data_id].remove(obj)
-        if len(list(self.object_data.get(data_id, []))) == 0:
+        objects = self.object_data.get(data_id)
+        if not objects:
+            return
+
+        obj_to_remove = [obj for obj in objects if only_data is None or obj == only_data]
+        for obj in obj_to_remove:
+            if remove:
+                remove_prop(self.renderer, obj)
+
+        self.object_data[data_id] = [obj for obj in objects if obj not in obj_to_remove]
+
+        if not self.object_data[data_id]:
             self.object_data.pop(data_id)
 
     def get_data(self, data_id):

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
@@ -1,0 +1,50 @@
+import logging
+from collections import defaultdict
+from typing import Any
+
+from vtkmodules.vtkRenderingCore import vtkRenderer
+
+from ....utils import (
+    get_image_data,
+    remove_prop,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ObjectHandler:
+    def __init__(self) -> None:
+        self.object_data = defaultdict(list)
+        self.renderer: vtkRenderer | None = None
+
+    def set_renderer(self, renderer: vtkRenderer) -> None:
+        self.renderer = renderer
+
+    def register_data(self, data_id: str, data: Any) -> None:
+        self.object_data[data_id].append(data)
+
+    def unregister_data(self, data_id, only_data=None, remove=True):
+        for obj in list(self.object_data.get(data_id, [])):
+            if only_data is None or obj == only_data:
+                if remove:
+                    remove_prop(self.renderer, obj)
+                self.object_data[data_id].remove(obj)
+        if len(list(self.object_data.get(data_id, []))) == 0:
+            self.object_data.pop(data_id)
+
+    def get_data(self, data_id):
+        data = self.object_data.get(data_id, [])
+        return data[0] if len(data) else None
+
+    def get_actors(self, data_id):
+        data = [self.object_data[data_id]] if data_id in self.object_data else self.object_data.values()
+        return [obj for objs in data for obj in objs if obj.IsA("vtkActor")]
+
+    def get_image_data(self, data_id):
+        data = [self.object_data[data_id]] if data_id in self.object_data else self.object_data.values()
+        image_data = [get_image_data(obj) for objs in data for obj in objs if get_image_data(obj) is not None]
+        return image_data[0] if len(image_data) > 0 else None
+
+    def get_glyph_actors(self, data_id):
+        data = [self.object_data[data_id]] if data_id in self.object_data else self.object_data.values()
+        return [obj for objs in data for obj in objs if hasattr(obj, 'GetMapper') and obj.GetMapper().IsA("vtkGlyph3DMapper")]

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -79,6 +79,7 @@ class VolumeSliceHandler(ObjectHandler):
             self.set_volume_normal_color(
                 data_id,
                 display_property.normal_color.show_arrows,
+                display_property.normal_color.sampling,
                 display_property.normal_color.arrow_length,
                 display_property.normal_color.arrow_width,
                 orientation,
@@ -236,6 +237,7 @@ class VolumeThreeDHandler(ObjectHandler):
             self.set_volume_normal_color(
                 data_id,
                 display_property.normal_color.show_arrows,
+                display_property.normal_color.sampling,
                 display_property.normal_color.arrow_length,
                 display_property.normal_color.arrow_width,
             )

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -30,31 +30,32 @@ from ....utils import (
     set_vector_field_sampling,
     set_volume_visibility,
 )
+from ...scene.objects.volume_object_logic import VolumeDisplay
 from .object_handler import ObjectHandler
 
 logger = logging.getLogger(__name__)
 
 
-class VolumeTwoDHandler(ObjectHandler):
-    def __init__(self, preset_parser: ColorPresetParser):
+class VolumeSliceHandler(ObjectHandler):
+    def __init__(self, preset_parser: ColorPresetParser) -> None:
         super().__init__()
         self.preset_parser = preset_parser
 
-    def _is_primary_volume(self, data_id):
+    def _is_primary_volume(self, data_id: str) -> bool:
         data = self.get_data(data_id)
         return isinstance(data, vtkResliceImageViewer)
 
-    def _is_secondary_volume(self, data_id):
+    def _is_secondary_volume(self, data_id: str) -> bool:
         data = self.get_data(data_id)
         return isinstance(data, vtkImageSlice)
 
-    def _has_multiple_primary_volumes(self):
+    def _has_multiple_primary_volumes(self) -> bool:
         return len([data_id for data_id in self.object_data if self._is_primary_volume(data_id)]) > 1
 
-    def has_primary_volume(self):
+    def has_primary_volume(self) -> bool:
         return self.get_reslice_image_viewer() is not None
 
-    def has_secondary_volume(self):
+    def has_secondary_volume(self) -> bool:
         return len(self.get_image_slices()) > 0
 
     def unregister_data(self, data_id: str, only_data: Any) -> None:
@@ -62,7 +63,28 @@ class VolumeTwoDHandler(ObjectHandler):
         remove_prop = not (self._is_primary_volume(data_id) and self._has_multiple_primary_volumes())
         super().unregister_data(data_id, only_data, remove_prop)
 
-    def add_primary_volume(self, data_id: str, image_data: vtkImageData, orientation: int):
+    def apply_volume_display_properties(
+        self, data_id: str, display_property: VolumeDisplay, orientation: int, is_primary: bool
+    ) -> None:
+        self.set_volume_window_level_min_max(data_id, display_property.window_level)
+        if not is_primary:
+            self.set_volume_opacity(data_id, display_property.opacity)
+        elif display_property.twod_color is not None:
+            self.set_volume_scalar_color_preset(
+                data_id,
+                display_property.twod_color.name,
+                display_property.twod_color.is_inverted,
+            )
+        elif display_property.normal_color is not None:
+            self.set_volume_normal_color(
+                data_id,
+                display_property.normal_color.show_arrows,
+                display_property.normal_color.arrow_length,
+                display_property.normal_color.arrow_width,
+                orientation,
+            )
+
+    def add_primary_volume(self, data_id: str, image_data: vtkImageData, orientation: int) -> None:
         reslice_image_viewer = render_volume_in_slice(image_data, self.renderer, orientation)
         self.register_data(data_id, reslice_image_viewer)
 
@@ -86,7 +108,7 @@ class VolumeTwoDHandler(ObjectHandler):
             modified = set_actor_visibility(glyph_actor, visible) or modified
         return modified
 
-    def set_volume_opacity(self, data_id, opacity) -> bool:
+    def set_volume_opacity(self, data_id: str, opacity: float) -> bool:
         logger.debug(f"set_volume_opacity({data_id}): {opacity}")
         modified = False
         reslice_image_viewer = self.get_reslice_image_viewer(data_id)
@@ -98,7 +120,7 @@ class VolumeTwoDHandler(ObjectHandler):
             modified = set_actor_opacity(glyph_actor, opacity) or modified
         return modified
 
-    def set_volume_window_level(self, data_id, window_level) -> bool:
+    def set_volume_window_level(self, data_id: str, window_level: tuple[float]) -> bool:
         logger.debug(f"set_volume_window_level({data_id}): {window_level}")
         modified = False
         reslice_image_viewer = self.get_reslice_image_viewer(data_id)
@@ -108,7 +130,7 @@ class VolumeTwoDHandler(ObjectHandler):
             modified = set_slice_window_level(slice, window_level) or modified
         return modified
 
-    def set_volume_window_level_min_max(self, data_id, window_level_min_max) -> bool:
+    def set_volume_window_level_min_max(self, data_id: str, window_level_min_max: list[float]) -> bool:
         """
         :see-also set_volume_window_level
         """
@@ -174,7 +196,7 @@ class VolumeTwoDHandler(ObjectHandler):
         ids = [data_id] if data_id in self.object_data else self.object_data.keys()
         return [self.get_data(id) for id in ids if self._is_secondary_volume(id)]
 
-    def set_segment_color(self, data_id, segment_id: int, color: str):
+    def set_segment_color(self, data_id: str, segment_id: int, color: str) -> None:
         # color format: #rrggbb
         color_value = [
             int(color[1:3], base=16) / 255.0,
@@ -188,7 +210,7 @@ class VolumeTwoDHandler(ObjectHandler):
             value[1:4] = color_value
             lut.SetNodeValue(segment_id, value)
 
-    def set_segment_visibility(self, data_id, segment_id: int, visible: bool):
+    def set_segment_visibility(self, data_id: str, segment_id: int, visible: bool) -> None:
         for image_slice in self.get_image_slices(data_id):
             lut: vtkDiscretizableColorTransferFunction = image_slice.GetProperty().GetLookupTable()
             of: vtkPiecewiseFunction = lut.GetScalarOpacityFunction()
@@ -199,9 +221,24 @@ class VolumeTwoDHandler(ObjectHandler):
 
 
 class VolumeThreeDHandler(ObjectHandler):
-    def __init__(self, preset_parser: VolumePresetParser):
+    def __init__(self, preset_parser: VolumePresetParser) -> None:
         super().__init__()
         self.preset_parser = preset_parser
+
+    def apply_volume_display_properties(self, data_id: str, display_property: VolumeDisplay) -> None:
+        if display_property.threed_color is not None:
+            self.set_volume_preset(
+                data_id,
+                display_property.threed_color.name,
+                display_property.threed_color.vr_shift,
+            )
+        elif display_property.normal_color is not None:
+            self.set_volume_normal_color(
+                data_id,
+                display_property.normal_color.show_arrows,
+                display_property.normal_color.arrow_length,
+                display_property.normal_color.arrow_width,
+            )
 
     def add_volume(self, data_id: str, image_data: vtkImageData) -> None:
         volume = render_volume_in_3D(image_data, self.renderer)
@@ -214,7 +251,7 @@ class VolumeThreeDHandler(ObjectHandler):
             return False
         return set_volume_visibility(volume, visible)
 
-    def set_volume_preset(self, data_id, preset_name, range) -> bool:
+    def set_volume_preset(self, data_id: str, preset_name: str, range: list[float]) -> bool:
         volume = self.get_data(data_id)
         if volume is None:
             return False

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -30,7 +30,7 @@ from ....utils import (
     set_vector_field_sampling,
     set_volume_visibility,
 )
-from .mesh_handler import ObjectHandler
+from .object_handler import ObjectHandler
 
 logger = logging.getLogger(__name__)
 

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -2,16 +2,15 @@ import logging
 from typing import Any
 
 from vtk import (
-    vtkDiscretizableColorTransferFunction,
     vtkImageData,
     vtkImageSlice,
-    vtkPiecewiseFunction,
     vtkResliceImageViewer,
 )
 
 from ....utils import (
     ColorPresetParser,
     VolumePresetParser,
+    convert_color_hex_to_normalized_rgb,
     render_labelmap_as_overlay_in_slice,
     render_volume_as_overlay_in_slice,
     render_volume_as_vector_field,
@@ -30,6 +29,7 @@ from ....utils import (
     set_vector_field_sampling,
     set_volume_visibility,
 )
+from ....utils.vtk.segmentation import set_segment_color, set_segment_visibility
 from ...scene.objects.volume_object_logic import VolumeDisplay
 from .object_handler import ObjectHandler
 
@@ -197,28 +197,18 @@ class VolumeSliceHandler(ObjectHandler):
         ids = [data_id] if data_id in self.object_data else self.object_data.keys()
         return [self.get_data(id) for id in ids if self._is_secondary_volume(id)]
 
-    def set_segment_color(self, data_id: str, segment_id: int, color: str) -> None:
-        # color format: #rrggbb
-        color_value = [
-            int(color[1:3], base=16) / 255.0,
-            int(color[3:5], base=16) / 255.0,
-            int(color[5:7], base=16) / 255.0,
-        ]
+    def set_segment_color(self, data_id: str, segment_id: int, color: str) -> bool:
+        color_tuple = convert_color_hex_to_normalized_rgb(color)
+        modified = False
         for image_slice in self.get_image_slices(data_id):
-            lut: vtkDiscretizableColorTransferFunction = image_slice.GetProperty().GetLookupTable()
-            value = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-            lut.GetNodeValue(segment_id, value)
-            value[1:4] = color_value
-            lut.SetNodeValue(segment_id, value)
+            modified = set_segment_color(image_slice, segment_id, color_tuple) or modified
+        return modified
 
-    def set_segment_visibility(self, data_id: str, segment_id: int, visible: bool) -> None:
+    def set_segment_visibility(self, data_id: str, segment_id: int, visible: bool) -> bool:
+        modified = False
         for image_slice in self.get_image_slices(data_id):
-            lut: vtkDiscretizableColorTransferFunction = image_slice.GetProperty().GetLookupTable()
-            of: vtkPiecewiseFunction = lut.GetScalarOpacityFunction()
-            value = [0.0, 0.0, 0.0, 0.0]
-            of.GetNodeValue(segment_id, value)
-            value[1] = float(visible)
-            of.SetNodeValue(segment_id, value)
+            modified = set_segment_visibility(image_slice, segment_id, visible) or modified
+        return modified
 
 
 class VolumeThreeDHandler(ObjectHandler):

--- a/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
@@ -1,7 +1,11 @@
 import logging
 from enum import Enum
 
-from ....ui import ViewType, ViewUI
+from vtk import vtkImageData, vtkPolyData, vtkRenderWindowInteractor
+from vtkmodules.vtkInteractionImage import vtkResliceImageViewer
+from vtkmodules.vtkInteractionWidgets import vtkResliceCursorWidget
+
+from ....ui import PointState, ViewType, ViewUI
 from ....utils import (
     VolumeLayer,
     debounce,
@@ -17,7 +21,9 @@ from ....utils import (
     set_reslice_normal,
     set_reslice_window_level,
 )
-from ..handlers.volume_handler import VolumeTwoDHandler
+from ...scene.objects.mesh_object_logic import MeshDisplay
+from ...scene.objects.volume_object_logic import VolumeDisplay
+from ..handlers.volume_handler import VolumeSliceHandler
 from ..place_roi_logic import PlaceROILogic
 from .view_logic import ViewLogic
 
@@ -40,7 +46,7 @@ class SliceViewLogic(ViewLogic):
     _debounced_flush_initialized = False
     DEBOUNCED_FLUSH = False
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.orientation = get_orientation_from_view_type(self.type)
 
@@ -57,7 +63,7 @@ class SliceViewLogic(ViewLogic):
             }
         )
 
-        self.volume_handler = VolumeTwoDHandler(self.color_preset_parser)
+        self.volume_handler = VolumeSliceHandler(self.color_preset_parser)
 
     @property
     def position(self) -> tuple[float]:
@@ -76,39 +82,55 @@ class SliceViewLogic(ViewLogic):
                 self._views_state.data.position.pos_z,
             ) = tuple(round(pos, 3) for pos in position_tuple)
 
-    def set_ui(self, ui: ViewUI):
+    def set_ui(self, ui: ViewUI) -> None:
         super().set_ui(ui)
         ui.slider_ui.slice_updated.connect(self.set_slice)
 
-    def reset(self):
+    def reset(self) -> None:
         reslice_image_viewer = self.volume_handler.get_reslice_image_viewer()
         if reslice_image_viewer is not None:
             reset_reslice(reslice_image_viewer)
             self.update()
 
-    def add_volume(self, data_id, image_data, layer: VolumeLayer, is_labelmap: bool):
+    def add_volume(
+        self,
+        data_id: str,
+        image_data: vtkImageData,
+        display_properties: VolumeDisplay,
+        layer: VolumeLayer,
+        is_labelmap: bool,
+    ):
+        is_primary = False
         if is_labelmap and layer == VolumeLayer.SECONDARY:
             self.volume_handler.add_labelmap(data_id, image_data, self.orientation.value)
         elif layer == VolumeLayer.PRIMARY:
+            is_primary = True
             self.volume_handler.add_primary_volume(data_id, image_data, self.orientation.value)
             self._set_reslice_interaction()
         elif layer == VolumeLayer.SECONDARY:
             self.volume_handler.add_secondary_volume(data_id, image_data, self.orientation.value)
+        else:
+            raise ValueError("Volume layer cannot be undefined.")
 
-    def add_mesh(self, data_id, poly_data):
-        self.mesh_handler.add_mesh_in_slice(data_id, poly_data, self.orientation)
+        self.volume_handler.apply_volume_display_properties(
+            data_id, display_properties, self.orientation.value, is_primary
+        )
 
-    def init_roi(self, roi: PlaceROILogic):
-        self.mesh_handler.add_mesh_in_slice(roi._id, roi.slice_rep, self.orientation)
+    def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: MeshDisplay) -> None:
+        self.mesh_handler.add_mesh_in_slice(data_id, poly_data, self.orientation.value)
+        self.mesh_handler.apply_mesh_display_properties(data_id, display_properties)
+
+    def init_roi(self, roi: PlaceROILogic) -> None:
+        self.mesh_handler.add_mesh_in_slice(roi._id, roi.slice_rep, self.orientation.value)
         self.mesh_handler.set_mesh_visibility(roi._id, False)
 
-    def flush(self):
+    def flush(self) -> None:
         if SliceViewLogic.DEBOUNCED_FLUSH:
             self.ctrl.debounced_flush()
         else:
             self.state.flush()
 
-    def _set_reslice_interaction(self):
+    def _set_reslice_interaction(self) -> None:
         reslice_image_viewer = self.volume_handler.get_reslice_image_viewer()
         reslice_cursor_widget = reslice_image_viewer.GetResliceCursorWidget()
         reslice_image_viewer.AddObserver("InteractionEvent", self.on_slice_scroll)
@@ -117,17 +139,17 @@ class SliceViewLogic(ViewLogic):
         reslice_image_viewer.GetInteractorStyle().AddObserver("WindowLevelEvent", self.on_window_leveling)
         self.on_reslice_cursor_interaction(reslice_image_viewer, None)
 
-    def on_obliques_visibility_changed(self, obliques_visibility, **_kwargs):
+    def on_obliques_visibility_changed(self, obliques_visibility: bool, **_kwargs) -> None:
         reslice_image_viewer = self.volume_handler.get_reslice_image_viewer()
         if reslice_image_viewer is not None:
             set_oblique_visibility(reslice_image_viewer, obliques_visibility)
             self.update()
 
-    def on_window_leveling(self, *_args):
+    def on_window_leveling(self, *_args) -> None:
         window_level_value = get_reslice_window_level(self.volume_handler.get_reslice_image_viewer())
         self.window_level_changed(window_level_value)
 
-    def on_slice_scroll(self, reslice_image_viewer, _event):
+    def on_slice_scroll(self, reslice_image_viewer: vtkResliceImageViewer, _event) -> None:
         """
         Triggered when scrolling the current image.
         There are 2 possible user interactions to modify the cursor:
@@ -143,7 +165,7 @@ class SliceViewLogic(ViewLogic):
         # flushed right away.
         self.flush()
 
-    def on_reslice_cursor_interaction(self, reslice_image_widget, _event):
+    def on_reslice_cursor_interaction(self, reslice_cursor_widget: vtkResliceCursorWidget, *_args) -> None:
         """
         Triggered when interacting with oblique lines.
         Because it is called within a co-routine, position is not flushed right away.
@@ -153,23 +175,23 @@ class SliceViewLogic(ViewLogic):
          - cursor interaction
         :see-also on_slice_scroll
         """
-        self.position = get_reslice_center(reslice_image_widget)
-        self._views_state.data.normals = get_reslice_normals(reslice_image_widget)
+        self.position = get_reslice_center(reslice_cursor_widget)
+        self._views_state.data.normals = get_reslice_normals(reslice_cursor_widget)
         # Flushing will trigger rendering
         self.flush()
 
-    def on_reslice_cursor_end_interaction(self, _reslice_image_widget, _event):
+    def on_reslice_cursor_end_interaction(self, *_args) -> None:
         self.state.flush()  # flush state.position
 
     @debounce(0.3)
-    def _update_slider(self, *_args):
+    def _update_slider(self, *_args) -> None:
         range = self.get_slice_range()
         self.data.slider_state.min_value = range[0]
         self.data.slider_state.max_value = range[1]
         self.data.slider_state.value = self.get_slice()
         self.flush()
 
-    def _update_position_and_normals_in_view(self, position, normals):
+    def _update_position_and_normals_in_view(self, position: PointState, normals: tuple[tuple[float]]) -> None:
         set_reslice_center(
             self.volume_handler.get_reslice_image_viewer(), (position.pos_x, position.pos_y, position.pos_z)
         )
@@ -178,29 +200,29 @@ class SliceViewLogic(ViewLogic):
         )
         self.flush()
 
-    def _on_position_or_normals_changed(self, position, normals):
+    def _on_position_or_normals_changed(self, position: PointState, normals: tuple[tuple[float]] | None) -> None:
         if position.pos_x is not None and normals is not None:
             self._update_position_and_normals_in_view(position, normals)
             self._update_slider()
 
             self.update()
 
-    def get_slice_range(self):
+    def get_slice_range(self) -> None:
         reslice_image_viewer = self.volume_handler.get_reslice_image_viewer()
         return [0, get_number_of_slices(reslice_image_viewer, self.orientation.value)]
 
-    def get_slice(self):
+    def get_slice(self) -> None:
         reslice_image_viewer = self.volume_handler.get_reslice_image_viewer()
         return get_slice_index_from_position(self.position, reslice_image_viewer, self.orientation.value)
 
-    def set_slice(self, slice):
+    def set_slice(self, slice: int) -> None:
         reslice_image_viewer = self.volume_handler.get_reslice_image_viewer()
         new_position = get_position_from_slice_index(slice, reslice_image_viewer, self.orientation.value)
         if new_position is not None and self.position != new_position:
             self.position = new_position
             self.flush()
 
-    def on_window_level_changed(self, window_level, **_kwargs):
+    def on_window_level_changed(self, window_level: tuple[float], **_kwargs) -> None:
         logger.debug(f"set_window_level: {window_level}")
         modified = set_reslice_window_level(self.volume_handler.get_reslice_image_viewer(), window_level)
         if modified:

--- a/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
@@ -1,9 +1,13 @@
 import logging
 
+from vtk import vtkImageData, vtkPolyData
+
 from ....utils import (
     VolumeLayer,
     reset_3D,
 )
+from ...scene.objects.mesh_object_logic import MeshDisplay
+from ...scene.objects.volume_object_logic import VolumeDisplay
 from ..handlers.volume_handler import VolumeThreeDHandler
 from ..place_roi_logic import PlaceROILogic
 from .view_logic import ViewLogic
@@ -12,21 +16,25 @@ logger = logging.getLogger(__name__)
 
 
 class ThreeDViewLogic(ViewLogic):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.volume_handler = VolumeThreeDHandler(self.volume_preset_parser)
 
-    def add_volume(self, data_id, image_data, layer: VolumeLayer, _is_labelmap: bool):
+    def add_volume(
+        self, data_id: str, image_data: vtkImageData, display_properties: VolumeDisplay, layer: VolumeLayer, _is_labelmap: bool
+    ) -> None:
         if layer == VolumeLayer.PRIMARY:
             self.volume_handler.add_volume(data_id, image_data)
+            self.volume_handler.apply_volume_display_properties(data_id, display_properties)
 
-    def add_mesh(self, data_id, poly_data):
+    def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: MeshDisplay) -> None:
         self.mesh_handler.add_mesh_in_3D(data_id, poly_data)
+        self.mesh_handler.apply_mesh_display_properties(data_id, display_properties)
 
-    def init_roi(self, roi: PlaceROILogic):
+    def init_roi(self, roi: PlaceROILogic) -> None:
         roi.box_widget.SetInteractor(self.renderer.GetRenderWindow().GetInteractor())
         roi.box_widget.SetCurrentRenderer(self.renderer)
 
-    def reset(self):
+    def reset(self) -> None:
         reset_3D(self.renderer)
         self.update()

--- a/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
@@ -16,8 +16,9 @@ class ThreeDViewLogic(ViewLogic):
         super().__init__(*args, **kwargs)
         self.volume_handler = VolumeThreeDHandler(self.volume_preset_parser)
 
-    def add_volume(self, data_id, image_data, _layer: VolumeLayer, _is_labelmap: bool):
-        self.volume_handler.add_volume(data_id, image_data)
+    def add_volume(self, data_id, image_data, layer: VolumeLayer, _is_labelmap: bool):
+        if layer == VolumeLayer.PRIMARY:
+            self.volume_handler.add_volume(data_id, image_data)
 
     def add_mesh(self, data_id, poly_data):
         self.mesh_handler.add_mesh_in_3D(data_id, poly_data)

--- a/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
@@ -1,20 +1,24 @@
 import logging
 from abc import abstractmethod
+from typing import Any
 
 from trame_server.core import Server
 from trame_server.utils.typed_state import TypedState
 from undo_stack import Signal
+from vtk import vtkImageData
 
 from ....ui import ViewsState, ViewState, ViewType, ViewUI
 from ....utils import (
     ColorPresetParser,
+    VolumeLayer,
     VolumePresetParser,
 )
 from ...base_logic import BaseLogic
+from ...scene.objects.volume_object_logic import VolumeDisplay
 from ..handlers.mesh_handler import MeshHandler
 from ..handlers.volume_handler import (
+    VolumeSliceHandler,
     VolumeThreeDHandler,
-    VolumeTwoDHandler,
 )
 from ..place_roi_logic import PlaceROILogic
 
@@ -30,45 +34,47 @@ class ViewLogic(BaseLogic[ViewState]):
         view_type: ViewType,
         volume_preset_parser: VolumePresetParser,
         color_preset_parser: ColorPresetParser,
-    ):
+    ) -> None:
         super().__init__(server, ViewState, view_type.value)
         self.type = view_type
         self.volume_preset_parser = volume_preset_parser
         self.color_preset_parser = color_preset_parser
 
         self.mesh_handler = MeshHandler(color_preset_parser)
-        self.volume_handler: VolumeTwoDHandler | VolumeThreeDHandler | None = None
+        self.volume_handler: VolumeSliceHandler | VolumeThreeDHandler | None = None
 
         self._views_state = TypedState(self.state, ViewsState)
 
-    def set_ui(self, ui: ViewUI):
+    def set_ui(self, ui: ViewUI) -> None:
         self.renderer = ui.renderer
         self.mesh_handler.set_renderer(ui.renderer)
         self.volume_handler.set_renderer(ui.renderer)
         self.update = ui.update
 
     @abstractmethod
-    def reset(self):
+    def reset(self) -> None:
         pass
 
     @abstractmethod
-    def add_volume(self, data_id, data):
+    def add_volume(
+        self, data_id: str, data: vtkImageData, display_properties: VolumeDisplay, layer: VolumeLayer
+    ) -> None:
         pass
 
     @abstractmethod
-    def add_mesh(self, data_id, data):
+    def add_mesh(self, data_id: str, data: vtkImageData) -> None:
         pass
 
     @abstractmethod
-    def init_roi(self, roi: PlaceROILogic):
+    def init_roi(self, roi: PlaceROILogic) -> None:
         pass
 
-    def remove_volume(self, data_id, only_data=None):
+    def remove_volume(self, data_id: str, only_data: Any | None = None) -> None:
         if self.volume_handler is None:
             return
         self.volume_handler.unregister_data(data_id, only_data)
 
-    def remove_mesh(self, data_id, only_data=None):
+    def remove_mesh(self, data_id: str, only_data: Any | None = None) -> None:
         if self.mesh_handler is None:
             return
         self.mesh_handler.unregister_data(data_id, only_data)

--- a/girdermedviewer/app/widgets/logic/vtk/views_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views_logic.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from trame_server.core import Server
 from trame_server.utils.typed_state import TypedState
 from undo_stack import Signal
@@ -11,6 +13,7 @@ from ...utils import (
     get_color_preset_parser,
     get_volume_preset_parser,
 )
+from ..scene.objects.volume_object_logic import VolumeDisplay
 from .place_roi_logic import PlaceROILogic
 from .segmentation_effect_logic import SegmentationEffectLogic
 from .views.slice_view_logic import SliceViewLogic
@@ -21,7 +24,7 @@ from .views.view_logic import ViewLogic
 class ViewsLogic(BaseLogic[ViewsState]):
     window_level_changed = Signal()
 
-    def __init__(self, server: Server):
+    def __init__(self, server: Server) -> None:
         super().__init__(server, ViewsState)
         self.view_logics: dict[ViewType, ViewLogic] = {}
         self.ctrl.reset = self.reset
@@ -58,7 +61,7 @@ class ViewsLogic(BaseLogic[ViewsState]):
     def threed_views(self) -> list[ThreeDViewLogic]:
         return [view for view in self.view_logics.values() if isinstance(view, ThreeDViewLogic)]
 
-    def _on_tool_change(self, active_tool: ToolType):
+    def _on_tool_change(self, active_tool: ToolType) -> None:
         self.roi_logic.enable_widget(active_tool == ToolType.PLACE_ROI)
         for view_logic in self.views:
             if isinstance(view_logic, SliceViewLogic):
@@ -69,11 +72,11 @@ class ViewsLogic(BaseLogic[ViewsState]):
 
         self.update_views()
 
-    def update_views(self):
+    def update_views(self) -> None:
         for view in self.views:
             view.update()
 
-    def update_slice_views(self):
+    def update_slice_views(self) -> None:
         for view in self.slice_views:
             view.update()
 
@@ -90,18 +93,18 @@ class ViewsLogic(BaseLogic[ViewsState]):
         # Init ROI
         self._init_roi()
 
-    def reset(self):
-        for view_logic in self.view_logics.values():
+    def reset(self) -> None:
+        for view_logic in self.views:
             view_logic.reset()
         self.update_views()
 
-    def add_mesh(self, data_id: str, poly_data: vtkPolyData):
-        for view_logic in self.view_logics.values():
-            view_logic.add_mesh(data_id, poly_data)
+    def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: VolumeDisplay) -> None:
+        for view_logic in self.views:
+            view_logic.add_mesh(data_id, poly_data, display_properties)
         self.update_views()
 
-    def remove_mesh(self, data_id: str, only_data=None):
-        for view_logic in self.view_logics.values():
+    def remove_mesh(self, data_id: str, only_data: Any = None) -> None:
+        for view_logic in self.views:
             view_logic.remove_mesh(data_id, only_data)
         self.update_views()
 
@@ -109,12 +112,13 @@ class ViewsLogic(BaseLogic[ViewsState]):
         self,
         data_id: str,
         image_data: vtkImageData,
+        display_properties: VolumeDisplay,
         layer: VolumeLayer,
         subtype: SceneObjectSubtype = SceneObjectSubtype.UNDEFINED,
     ):
         is_labelmap = subtype == SceneObjectSubtype.LABELMAP
-        for view_logic in self.view_logics.values():
-            view_logic.add_volume(data_id, image_data, layer, is_labelmap)
+        for view_logic in self.views:
+            view_logic.add_volume(data_id, image_data, display_properties, layer, is_labelmap)
 
         if layer == VolumeLayer.PRIMARY:
             self.data.are_obliques_visible = True
@@ -125,12 +129,13 @@ class ViewsLogic(BaseLogic[ViewsState]):
 
         if is_labelmap:
             self._tool_state.data.active_tool = ToolType.SEGMENTATION_EFFECT
+
         self.update_views()
 
-    def remove_volume(self, data_id: str, only_data=None):
+    def remove_volume(self, data_id: str, only_data: Any = None) -> None:
         has_primary_volume = False
         has_secondary_volume = False
-        for view_logic in self.view_logics.values():
+        for view_logic in self.views:
             view_logic.remove_volume(data_id, only_data)
 
             if isinstance(view_logic, SliceViewLogic):
@@ -148,6 +153,6 @@ class ViewsLogic(BaseLogic[ViewsState]):
 
         self.update_views()
 
-    def _init_roi(self):
-        for view_logic in self.view_logics.values():
+    def _init_roi(self) -> None:
+        for view_logic in self.views:
             view_logic.init_roi(self.roi_logic)

--- a/girdermedviewer/app/widgets/logic/vtk/views_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views_logic.py
@@ -72,13 +72,18 @@ class ViewsLogic(BaseLogic[ViewsState]):
 
         self.update_views()
 
+    def _is_view_shown(self, view_logic: ViewLogic) -> bool:
+        return self.data.fullscreen is None or self.data.fullscreen == view_logic.type
+
     def update_views(self) -> None:
         for view in self.views:
-            view.update()
+            if self._is_view_shown(view):
+                view.update()
 
     def update_slice_views(self) -> None:
         for view in self.slice_views:
-            view.update()
+            if self._is_view_shown(view):
+                view.update()
 
     def set_ui(self, ui: ViewsUI, tool_ui: ToolUI):
         self.roi_logic.roi_updated.connect(self.update_views)

--- a/girdermedviewer/app/widgets/ui/scene/filters/filter_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/filters/filter_ui.py
@@ -39,13 +39,12 @@ class FilterToolbarUI(html.Div):
 
 class FilterUI(html.Div):
     def __init__(self, obj: str, disabled: str, **kwargs) -> None:
-        super().__init__(**kwargs)
+        super().__init__(classes=(f"{disabled} ? 'disabled' : ''",), **kwargs)
         self._filter_type = f"{obj}.filter_type"
 
         with self, Provider(name="filter_prop", instance=(f"{obj}.filter_prop_id",)):
             self.gaussian_filter = GaussianFilterUI(
                 v_if=(self._is_filter_active(FilterType.GAUSSIAN_BLUR),),
-                disabled=disabled,
                 obj_filter_prop="filter_prop",
             )
 

--- a/girdermedviewer/app/widgets/ui/scene/filters/gaussian_filter_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/filters/gaussian_filter_ui.py
@@ -9,13 +9,12 @@ class GaussianSigmaSlider(Slider):
 
 
 class GaussianFilterUI(html.Div):
-    def __init__(self, obj_filter_prop: str, disabled: str, **kwargs):
+    def __init__(self, obj_filter_prop: str, **kwargs):
         super().__init__(**kwargs)
         self._filter_prop = obj_filter_prop
-        self._disabled = disabled
         self._build_ui()
 
     def _build_ui(self):
         with self:
             Text("Sigma", classes="text-header")
-            GaussianSigmaSlider(disabled=(self._disabled,), model=f"{self._filter_prop}.sigma")
+            GaussianSigmaSlider(model=f"{self._filter_prop}.sigma")

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_color_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_color_ui.py
@@ -147,7 +147,7 @@ class VolumeWindowLevelUI(html.Div):
                     v_model=f"{self.display}.window_level",
                     min=(f"{self.display}.scalar_range[0]",),
                     max=(f"{self.display}.scalar_range[1]",),
-                    disabled=(f"{self.display}.normal_color.show_arrows",),
+                    disabled=(f"{self.display}.normal_color?.show_arrows",),
                 ),
                 v3.Template(v_slot_append=True),
             ):
@@ -155,7 +155,7 @@ class VolumeWindowLevelUI(html.Div):
                     tooltip="Auto Window/Level",
                     icon="mdi-refresh-auto",
                     click=f"{self.display}.window_level = {self.display}.scalar_range",
-                    disabled=(f"{self.display}.normal_color.show_arrows",),
+                    disabled=(f"{self.display}.normal_color?.show_arrows",),
                 )
 
 

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
@@ -17,7 +17,6 @@ class VolumeDisplayUI(html.Div):
         self,
         obj_display: str,
         obj_subtype: str,
-        disabled: str,
         has_opacity: str,
         twod_presets: str,
         threed_presets: str,
@@ -28,7 +27,6 @@ class VolumeDisplayUI(html.Div):
         )
         self.display = obj_display
         self.subtype = obj_subtype
-        self.disabled = disabled
         self.has_opacity = has_opacity
         self.twod_presets = twod_presets
         self.threed_presets = threed_presets
@@ -75,16 +73,13 @@ class MeshDisplayUI(html.Div):
 
 class SceneObjectDisplayUI(html.Div):
     def __init__(self, obj: str, disabled: str, has_opacity: str, color_presets: str, volume_presets: str, **kwargs):
-        super().__init__(
-            **kwargs,
-        )
+        super().__init__(classes=(f"{disabled} ? 'disabled' : ''",), **kwargs)
         self.obj = obj
 
         with self, Provider(name="display", instance=(f"{self.obj}.display",)):
             VolumeDisplayUI(
                 obj_display="display",
                 obj_subtype=f"{self.obj}.object_subtype",
-                disabled=disabled,
                 has_opacity=has_opacity,
                 twod_presets=color_presets,
                 threed_presets=volume_presets,

--- a/girdermedviewer/app/widgets/ui/vtk/tools/place_roi_ui.py
+++ b/girdermedviewer/app/widgets/ui/vtk/tools/place_roi_ui.py
@@ -54,5 +54,5 @@ class PlaceROIUI(v3.VCard):
                     tooltip="Reset",
                 )
 
-    def _toggle_roi_interaction(self):
+    def _toggle_roi_interaction(self) -> None:
         self._typed_state.data.is_roi_locked = not self._typed_state.data.is_roi_locked

--- a/girdermedviewer/app/widgets/ui/vtk/tools/segmentation_effect_ui.py
+++ b/girdermedviewer/app/widgets/ui/vtk/tools/segmentation_effect_ui.py
@@ -74,7 +74,9 @@ class SegmentationEffectUI(v3.VCard):
                         text="Select segment",
                     )
 
-            with v3.VCardText():
+            with v3.VCardText(
+                classes=(f"{self.active_segment_id} == null ? 'disabled' : ''",),
+            ):
                 with html.Div(classes="d-flex justify-space-between"):
                     self._build_effect_button(
                         icon="mdi-cursor-default",
@@ -102,7 +104,6 @@ class SegmentationEffectUI(v3.VCard):
             tooltip=effect_type.value,
             active=(self._is_active_effect(effect_type),),
             click=self._set_active_effect(effect_type),
-            disabled=(f"{self.active_segment_id} == null",),
             **kwargs,
         )
 

--- a/girdermedviewer/app/widgets/utils/__init__.py
+++ b/girdermedviewer/app/widgets/utils/__init__.py
@@ -1,4 +1,9 @@
-from .app_utils import AppConfig, debounce, is_valid_url
+from .app_utils import (
+    AppConfig,
+    convert_color_hex_to_normalized_rgb,
+    debounce,
+    is_valid_url,
+)
 from .components_utils import (
     Button,
     ColorPicker,
@@ -85,7 +90,6 @@ from .vtk.vtk_utils import (
     supported_volume_extensions,
 )
 
-
 __all__ = [
     "ICONS_MAP",
     "AppConfig",
@@ -121,6 +125,7 @@ __all__ = [
     "VolumeLayer",
     "VolumePresetParser",
     "are_same_paths",
+    "convert_color_hex_to_normalized_rgb",
     "create_gaussian_filter",
     "create_rendering_pipeline",
     "debounce",

--- a/girdermedviewer/app/widgets/utils/app_utils.py
+++ b/girdermedviewer/app/widgets/utils/app_utils.py
@@ -89,3 +89,8 @@ def debounce(wait, disabled=False):
     if disabled:
         return lambda func: func
     return decorator
+
+
+def convert_color_hex_to_normalized_rgb(hex_color) -> tuple[float]:
+    hex = hex_color.lstrip("#")
+    return tuple(round(int(hex[i : i + 2], 16) / 255.0, 3) for i in (0, 2, 4))

--- a/girdermedviewer/app/widgets/utils/components_utils.py
+++ b/girdermedviewer/app/widgets/utils/components_utils.py
@@ -185,6 +185,7 @@ class GlobalStyle(Style):
             ".display-property { gap: 12px; display: flex; flex-direction: column; } "
             ".display-property-divider { margin-top: 12px; margin-bottom: 12px; } "
             ".display-property-setting { gap: 12px; display: flex; flex-direction: row; align-items: center; } "
+            ".disabled { pointer-events: none; opacity: 0.5; } "
             ".drawer .v-navigation-drawer__content { display: flex; flex-direction: column; padding: 12px; justify-content: space-between;} "
             ".fullscreen-view { position: relative; width: 100% !important; height: 100% !important; }"
             ".girder-browser { width: 100%; } "

--- a/girdermedviewer/app/widgets/utils/vtk/segmentation.py
+++ b/girdermedviewer/app/widgets/utils/vtk/segmentation.py
@@ -30,7 +30,7 @@ from vtkmodules.vtkRenderingCore import (
     vtkRenderWindowInteractor,
 )
 
-from girdermedviewer.app.widgets.utils.vtk.vtk_utils import realign_axes
+from .vtk_utils import realign_axes
 
 
 def _vtk_image_to_np(image: vtkImageData) -> np.ndarray:

--- a/girdermedviewer/app/widgets/utils/vtk/segmentation.py
+++ b/girdermedviewer/app/widgets/utils/vtk/segmentation.py
@@ -6,7 +6,12 @@ import vtkmodules.util.numpy_support as vtknp
 from numpy.typing import NDArray
 from undo_stack import Signal
 from vtkmodules.vtkCommonCore import VTK_UNSIGNED_CHAR, vtkCommand, vtkPoints
-from vtkmodules.vtkCommonDataModel import vtkImageData, vtkPlane, vtkPolyData
+from vtkmodules.vtkCommonDataModel import (
+    vtkImageData,
+    vtkPiecewiseFunction,
+    vtkPlane,
+    vtkPolyData,
+)
 from vtkmodules.vtkCommonExecutionModel import vtkAlgorithmOutput, vtkPolyDataAlgorithm
 from vtkmodules.vtkCommonMath import vtkMatrix4x4
 from vtkmodules.vtkCommonTransforms import vtkTransform
@@ -22,6 +27,8 @@ from vtkmodules.vtkInteractionImage import vtkResliceImageViewer
 from vtkmodules.vtkInteractionWidgets import vtkResliceCursor, vtkResliceCursorWidget
 from vtkmodules.vtkRenderingCore import (
     vtkActor,
+    vtkDiscretizableColorTransferFunction,
+    vtkImageSlice,
     vtkPolyDataMapper,
     vtkProp,
     vtkProperty,
@@ -70,6 +77,33 @@ def _subextent_to_slices(extent: list[int], subextent: list[int]) -> tuple[slice
             subextent[0] - extent[0] + (subextent[1] - subextent[0] + 1),
         ),
     )
+
+
+def set_segment_color(image_slice: vtkImageSlice, segment_id: int, color: tuple[float]) -> bool:
+    lut: vtkDiscretizableColorTransferFunction = image_slice.GetProperty().GetLookupTable()
+    value = [0.0] * 6
+    lut.GetNodeValue(segment_id, value)
+
+    if color == value[1:4]:
+        return False
+
+    value[1:4] = color
+    lut.SetNodeValue(segment_id, value)
+    return True
+
+
+def set_segment_visibility(image_slice: vtkImageSlice, segment_id: int, visible: bool) -> bool:
+    lut: vtkDiscretizableColorTransferFunction = image_slice.GetProperty().GetLookupTable()
+    of: vtkPiecewiseFunction = lut.GetScalarOpacityFunction()
+    value = [0.0, 0.0, 0.0, 0.0]
+    of.GetNodeValue(segment_id, value)
+
+    if value[1] == float(visible):
+        return False
+
+    value[1] = float(visible)
+    of.SetNodeValue(segment_id, value)
+    return True
 
 
 class LabelMapOperation(IntEnum):

--- a/girdermedviewer/app/widgets/utils/vtk/vtk_utils.py
+++ b/girdermedviewer/app/widgets/utils/vtk/vtk_utils.py
@@ -161,12 +161,14 @@ def get_reslice_window_level(reslice_image_viewer):
 
 
 def set_reslice_visibility(reslice_image_viewer: vtkResliceImageViewer, visible: bool) -> bool:
-    alpha = (float(visible), float(visible))
-    lut = reslice_image_viewer.GetWindowLevel().GetLookupTable()
-    if lut.GetAlphaRange() == alpha:
-        return False
-    lut.SetAlphaRange(*alpha)
-    lut.Build()
+    opacity = float(visible)
+    lut = reslice_image_viewer.GetLookupTable()
+    n = lut.GetNumberOfTableValues()
+    for i in range(n):
+        r, g, b, old_opacity = lut.GetTableValue(i)
+        if old_opacity == opacity:
+            return False
+        lut.SetTableValue(i, r, g, b, opacity)
     return True
 
 
@@ -174,15 +176,6 @@ def set_reslice_opacity(_reslice_image_viewer, opacity):
     if opacity != 1:
         logger.warning("not implemented")
     return False
-    # reslice_representation = get_reslice_cursor_representation(reslice_image_viewer)
-    # if reslice_representation is None:
-    #     return False
-    # reslice_actor = reslice_representation.GetImageActor() => should be GetTexturedActor
-    # reslice_property = reslice_actor.GetProperty()
-    # if reslice_property.GetOpacity() == opacity:
-    #     return False
-    # reslice_property.SetOpacity(opacity)
-    # return True
 
 
 def realign_axes(reslice_image_viewer: vtkResliceImageViewer):


### PR DESCRIPTION
- **Only render primary volume in 3D view** ⚠️ will be partially rolled back later by adding a toggle to show/hide the volume rendering
- **Directly render object with their properties:** fixes the double update in the viewer that was noticeable and fixes missing display property after a reload (as primary or secondary). Closes #45 
- **Updates only the visible views:** all views if quadview or only one if fullscrren
- **Fixes competition of primary volumes for reslice image viewer:** only visible volumes can be edited, thus only one primary volume can edit the reslice image viewer display
- **Fixes missing updates after segment color or visibility change**