### PR TITLE
UI fixes

### DIFF
--- a/girdermedviewer/app/widgets/logic/girder/girder_load_logic.py
+++ b/girdermedviewer/app/widgets/logic/girder/girder_load_logic.py
@@ -88,6 +88,7 @@ class GirderLoadLogic(BaseLogic[None]):
             try:
                 await self._fetch_item(task_id, item)
             finally:
+                self.state.flush()
                 self.fetch_tasks.pop(task_id, None)
 
         self.fetch_tasks[task_id] = create_task(_fetch())

--- a/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
@@ -113,6 +113,3 @@ class MeshHandler(ObjectHandler):
 
     def unregister_object_from_views(self, mesh_logic: MeshObjectLogic) -> None:
         self.views_logic.remove_mesh(mesh_logic._id)
-
-    def set_object_visibility(self, mesh_logic: MeshObjectLogic, visible: bool) -> None:
-        mesh_logic.scene_object.is_visible = visible

--- a/girdermedviewer/app/widgets/logic/scene/handlers/object_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/object_handler.py
@@ -38,6 +38,5 @@ class ObjectHandler(BaseLogic[SceneState]):
     def unregister_object_from_views(self, object_logic: SceneObjectLogic) -> None:
         pass
 
-    @abstractmethod
     def set_object_visibility(self, object_logic: SceneObjectLogic, visible: bool) -> None:
-        pass
+        object_logic.scene_object.is_visible = visible

--- a/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
@@ -105,9 +105,6 @@ class SegmentationHandler(ObjectHandler):
         if self.data.active_labelmap_id == seg_filter_logic._id:
             self.select_segment_in_labelmap(None)
 
-    def set_object_visibility(self, seg_filter_logic: SegmentationFilterLogic, visible: bool) -> None:
-        seg_filter_logic.scene_object.is_visible = visible
-
     def _connect_labelmap_to_display_handler(self, seg_filter_logic: SegmentationFilterLogic):
         seg_filter_logic.display.watch(("opacity",), self._display_handler.update_opacity(seg_filter_logic))
         seg_filter_logic.scene_object.watch(("is_visible",), self._display_handler.update_visibility(seg_filter_logic))

--- a/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
@@ -190,7 +190,13 @@ class VolumeHandler(ObjectHandler):
             self._add_to_primary_volumes(volume_logic._id)
             self._set_active_primary_volume_id(volume_logic._id)
 
-        self.views_logic.add_volume(volume_logic._id, volume_logic.object_data, volume_logic.display, layer)
+        self.views_logic.add_volume(
+            volume_logic._id,
+            volume_logic.object_data,
+            volume_logic.display,
+            layer,
+            volume_logic.scene_object.object_subtype,
+        )
 
     def _reload_as_primary_volume(self, volume_logic: VolumeObjectLogic) -> None:
         self.views_logic.remove_volume(volume_logic._id)

--- a/girdermedviewer/app/widgets/logic/scene/objects/mesh_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/mesh_object_logic.py
@@ -42,6 +42,7 @@ class MeshObjectLogic(SceneObjectLogic):
             array_color=ArrayColor(self.server),
         )
         self.scene_object.display = self.display._id
+        self.scene_object.flush()
 
     def load_object_data(self, file_path: str) -> None:
         self.object_data = load_mesh(file_path)

--- a/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
@@ -44,7 +44,7 @@ class BaseVolumeObjectLogic(SceneObjectLogic):
             self.server,
         )
         self.scene_object.display = self.display._id
-
+        self.scene_object.flush()
 
 class VolumeObjectLogic(BaseVolumeObjectLogic):
     def __init__(self, *args, **kwargs) -> None:
@@ -70,7 +70,6 @@ class VolumeObjectLogic(BaseVolumeObjectLogic):
             self.display.window_level = self.scalar_range
             # Init 3D preset range
             self.display.threed_color.vr_shift = self.scalar_range
-
     def load_object_data(self, file_path: str) -> None:
         self.object_data = load_volume(file_path)
         self._init_display_properties()

--- a/girdermedviewer/app/widgets/logic/scene/scene_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/scene_logic.py
@@ -173,8 +173,6 @@ class SceneLogic(BaseLogic[SceneState]):
         self.scene.objects = [*self.scene.objects, scene_object]
         self.object_added(scene_object._id)
 
-        self.state.flush()  # FIXME: need to flush manually
-
     def add_file_object_to_views(self, file_path: str, object_id: str) -> None:
         # Check that object has been created
         scene_object: SceneObject = next((obj for obj in self.scene.objects if obj._id == object_id), None)

--- a/girdermedviewer/app/widgets/logic/scene/scene_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/scene_logic.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 class SceneGUI(StateDataModel):
-    expanded_objects = Sync(list[str], list)
+    expanded_object = Sync(str, list)
 
 
 class Scene(StateDataModel):
@@ -44,7 +44,7 @@ class SceneLogic(BaseLogic[SceneState]):
     def __init__(self, server: Server, views_logic: ViewsLogic) -> None:
         super().__init__(server, SceneState)
 
-        self.scene = Scene(self.server, gui=SceneGUI(self.server, gui=SceneGUI(self.server)))
+        self.scene = Scene(self.server, gui=SceneGUI(self.server))
         self.data.scene_id = self.scene._id
         self.object_logics: dict[str, SceneObjectLogic] = {}
         self._init_presets(views_logic)
@@ -143,6 +143,7 @@ class SceneLogic(BaseLogic[SceneState]):
         self._get_object_handler(object_logic).add_object_to_views(object_logic)
         object_logic.set_loading_status(False)
         object_logic.set_icon()
+        self.scene.gui.expanded_object = object_logic._id
 
         self.object_logics[object_logic._id] = object_logic
 

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -279,4 +279,4 @@ class VolumeThreeDHandler(ObjectHandler):
             modified = set_vector_field_arrow_length(glyph_actor, arrow_length) or modified
             modified = set_vector_field_arrow_thickness(glyph_actor, arrow_width) or modified
 
-        return set_volume_visibility(volume, not show_arrows) or modified
+        return modified

--- a/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
@@ -7,6 +7,7 @@ from vtkmodules.vtkInteractionWidgets import vtkResliceCursorWidget
 
 from ....ui import PointState, ViewType, ViewUI
 from ....utils import (
+    SceneObjectSubtype,
     VolumeLayer,
     debounce,
     get_number_of_slices,
@@ -98,10 +99,10 @@ class SliceViewLogic(ViewLogic):
         image_data: vtkImageData,
         display_properties: VolumeDisplay,
         layer: VolumeLayer,
-        is_labelmap: bool,
+        subtype: SceneObjectSubtype,
     ):
         is_primary = False
-        if is_labelmap and layer == VolumeLayer.SECONDARY:
+        if subtype == SceneObjectSubtype.LABELMAP and layer == VolumeLayer.SECONDARY:
             self.volume_handler.add_labelmap(data_id, image_data, self.orientation.value)
         elif layer == VolumeLayer.PRIMARY:
             is_primary = True

--- a/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
@@ -3,6 +3,7 @@ import logging
 from vtk import vtkImageData, vtkPolyData
 
 from ....utils import (
+    SceneObjectSubtype,
     VolumeLayer,
     reset_3D,
 )
@@ -21,11 +22,21 @@ class ThreeDViewLogic(ViewLogic):
         self.volume_handler = VolumeThreeDHandler(self.volume_preset_parser)
 
     def add_volume(
-        self, data_id: str, image_data: vtkImageData, display_properties: VolumeDisplay, layer: VolumeLayer, _is_labelmap: bool
+        self,
+        data_id: str,
+        image_data: vtkImageData,
+        display_properties: VolumeDisplay,
+        layer: VolumeLayer,
+        subtype: SceneObjectSubtype,
     ) -> None:
-        if layer == VolumeLayer.PRIMARY:
-            self.volume_handler.add_volume(data_id, image_data)
-            self.volume_handler.apply_volume_display_properties(data_id, display_properties)
+        if subtype in [SceneObjectSubtype.LABELMAP, SceneObjectSubtype.SCALAR] and layer == VolumeLayer.SECONDARY:
+            return
+
+        self.volume_handler.add_volume(data_id, image_data)
+        self.volume_handler.apply_volume_display_properties(data_id, display_properties)
+
+        if subtype == SceneObjectSubtype.VECTOR and layer == VolumeLayer.SECONDARY:
+            self.volume_handler.set_volume_visibility(data_id, False)
 
     def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: MeshDisplay) -> None:
         self.mesh_handler.add_mesh_in_3D(data_id, poly_data)

--- a/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
@@ -10,6 +10,7 @@ from vtk import vtkImageData
 from ....ui import ViewsState, ViewState, ViewType, ViewUI
 from ....utils import (
     ColorPresetParser,
+    SceneObjectSubtype,
     VolumeLayer,
     VolumePresetParser,
 )
@@ -57,7 +58,12 @@ class ViewLogic(BaseLogic[ViewState]):
 
     @abstractmethod
     def add_volume(
-        self, data_id: str, data: vtkImageData, display_properties: VolumeDisplay, layer: VolumeLayer
+        self,
+        data_id: str,
+        data: vtkImageData,
+        display_properties: VolumeDisplay,
+        layer: VolumeLayer,
+        subtype: SceneObjectSubtype,
     ) -> None:
         pass
 

--- a/girdermedviewer/app/widgets/logic/vtk/views_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views_logic.py
@@ -119,11 +119,10 @@ class ViewsLogic(BaseLogic[ViewsState]):
         image_data: vtkImageData,
         display_properties: VolumeDisplay,
         layer: VolumeLayer,
-        subtype: SceneObjectSubtype = SceneObjectSubtype.UNDEFINED,
+        subtype: SceneObjectSubtype,
     ):
-        is_labelmap = subtype == SceneObjectSubtype.LABELMAP
         for view_logic in self.views:
-            view_logic.add_volume(data_id, image_data, display_properties, layer, is_labelmap)
+            view_logic.add_volume(data_id, image_data, display_properties, layer, subtype)
 
         if layer == VolumeLayer.PRIMARY:
             self.data.are_obliques_visible = True
@@ -132,7 +131,7 @@ class ViewsLogic(BaseLogic[ViewsState]):
             self.roi_logic.set_default_bounds(image_data.GetBounds())
             self.segmentation_logic.set_paint_effects(self.slice_views)
 
-        if is_labelmap:
+        if subtype == SceneObjectSubtype.LABELMAP:
             self._tool_state.data.active_tool = ToolType.SEGMENTATION_EFFECT
 
         self.update_views()

--- a/girdermedviewer/app/widgets/ui/app_ui.py
+++ b/girdermedviewer/app/widgets/ui/app_ui.py
@@ -41,15 +41,14 @@ class AppLayout(VAppLayout):
                 disable_resize_watcher=True,
                 disable_route_watcher=True,
                 permanent=True,
-                width=500,
+                width=510,
             )
 
             self.tool_strip = v3.VNavigationDrawer(
-                classes="tool-strip",
                 disable_resize_watcher=True,
                 disable_route_watcher=True,
                 permanent=True,
-                width=50,
+                width=40,
             )
 
             self.viewer = v3.VMain(classes="d-flex flex-row flex-grow-1")

--- a/girdermedviewer/app/widgets/ui/girder/girder_browser_ui.py
+++ b/girdermedviewer/app/widgets/ui/girder/girder_browser_ui.py
@@ -48,6 +48,7 @@ class GirderBrowserUI(html.Div):
                 disabled=(f"!{self._typed_state.name.is_user_connected}",),
                 icon="mdi-file-plus-outline",
                 tooltip="Browse data",
+                size="default",
             ),
             v3.VDialog(
                 v_model=(self._typed_state.name.is_browser_dialog_visible,),

--- a/girdermedviewer/app/widgets/ui/scene/filters/segmentation_filter_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/filters/segmentation_filter_ui.py
@@ -55,6 +55,7 @@ class SegmentList(v3.VList):
                 Button(
                     icon="mdi-circle",
                     color=("segment.color",),
+                    size="small",
                 ),
             ):
                 SegmentColorDialog(segment="segment", activator="parent")
@@ -66,16 +67,15 @@ class SegmentList(v3.VList):
                 )
 
             with v3.Template(v_slot_append=True):
-                v3.VIcon(
-                    classes="mr-2",
+                Button(
                     icon=("segment.is_visible ? 'mdi-eye-outline' : 'mdi-eye-off-outline'",),
-                    click_native_stop="segment.is_visible = !segment.is_visible;",
-                    __events=[("click_native_stop", "click.native.stop")],
+                    click_stop="segment.is_visible = !segment.is_visible",
+                    size="small",
                 )
-                v3.VIcon(
-                    icon="mdi-delete-outline",
-                    click_native_stop=(self.delete_segment_clicked, f"[{self._obj_id}, segment._id]"),
-                    __events=[("click_native_stop", "click.native.stop")],
+                Button(
+                    icon="mdi-close",
+                    click_stop=(self.delete_segment_clicked, f"[{self._obj_id}, segment._id]"),
+                    size="small",
                 )
 
 

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_color_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_color_ui.py
@@ -183,6 +183,7 @@ class VolumeDisplayTwoDColorUI(html.Div):
                     v_model=(f"{self.display}.twod_color.is_inverted",),
                     label="Invert",
                     hide_details=True,
+                    density="compact",
                 )
 
             VolumeWindowLevelUI(self.display)

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_color_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_color_ui.py
@@ -92,6 +92,7 @@ class MeshDisplayColorUI(html.Div):
                                 v_model=("array_color.is_inverted",),
                                 label="Invert",
                                 hide_details=True,
+                                density="compact",
                             )
                     with html.Div(classes="display-property-setting"):
                         Text("Range", classes="text-subtitle")
@@ -118,11 +119,11 @@ class VolumeDisplayThreeDColorUI(html.Div):
             (
                 PresetSelector(
                     items=(self.threed_presets,),
-                    v_model=(f"{self.display}.threed_color.name"),
+                    v_model=(f"{self.display}.threed_color.name",),
                 ),
             )
             with html.Div(classes="display-property-setting"):
-                Text("Volume Rendering Shift", classes="text-subtitle")
+                Text("Rendering Shift", classes="text-subtitle")
                 RangeSlider(
                     v_model=(f"{self.display}.threed_color.vr_shift",),
                     min=(f"{self.display}.scalar_range[0]",),
@@ -131,12 +132,13 @@ class VolumeDisplayThreeDColorUI(html.Div):
 
 
 class VolumeWindowLevelUI(html.Div):
-    def __init__(self, obj_display: str, **kwargs):
+    def __init__(self, obj_display: str, is_disabled: str | None = None, **kwargs):
         super().__init__(
             classes="display-property-setting",
             **kwargs,
         )
         self.display = obj_display
+        self.disabled = is_disabled
         self._build_ui()
 
     def _build_ui(self) -> None:
@@ -147,7 +149,7 @@ class VolumeWindowLevelUI(html.Div):
                     v_model=f"{self.display}.window_level",
                     min=(f"{self.display}.scalar_range[0]",),
                     max=(f"{self.display}.scalar_range[1]",),
-                    disabled=(f"{self.display}.normal_color?.show_arrows",),
+                    disabled=(self.disabled,),
                 ),
                 v3.Template(v_slot_append=True),
             ):
@@ -155,7 +157,7 @@ class VolumeWindowLevelUI(html.Div):
                     tooltip="Auto Window/Level",
                     icon="mdi-refresh-auto",
                     click=f"{self.display}.window_level = {self.display}.scalar_range",
-                    disabled=(f"{self.display}.normal_color?.show_arrows",),
+                    disabled=(self.disabled,),
                 )
 
 
@@ -175,7 +177,7 @@ class VolumeDisplayTwoDColorUI(html.Div):
             with (
                 PresetSelector(
                     items=(self.twod_presets,),
-                    v_model=(f"{self.display}.twod_color.name"),
+                    v_model=(f"{self.display}.twod_color.name",),
                 ),
                 v3.Template(v_slot_append=True),
             ):
@@ -236,4 +238,4 @@ class VolumeDisplayNormalColorUI(html.Div):
                     precision=2,
                 )
 
-            VolumeWindowLevelUI(self.display)
+            VolumeWindowLevelUI(self.display, disabled=f"{self.display}.normal_color.show_arrows")

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
@@ -36,12 +36,18 @@ class VolumeDisplayUI(html.Div):
         with self:
             with html.Div(v_if=(self._is_volume_subtype(SceneObjectSubtype.SCALAR),)):
                 with html.Div(v_if=(self.is_primary,)):
-                    VolumeDisplayThreeDColorUI(self.display, self.threed_presets)
+                    VolumeDisplayThreeDColorUI(
+                        v_if=(f"{self.display}.threed_color",),
+                        obj_display=self.display,
+                        threed_presets=self.threed_presets,
+                    )
                     v3.VDivider(classes="display-property-divider")
-                VolumeDisplayTwoDColorUI(self.display, self.twod_presets)
+                VolumeDisplayTwoDColorUI(
+                    v_if=(f"{self.display}.twod_color",), obj_display=self.display, twod_presets=self.twod_presets
+                )
 
             with html.Div(v_if=(self._is_volume_subtype(SceneObjectSubtype.VECTOR),)):
-                VolumeDisplayNormalColorUI(self.display)
+                VolumeDisplayNormalColorUI(v_if=(f"{self.display}.normal_color",), obj_display=self.display)
 
             with html.Div(
                 v_if=(f"!{self.is_primary}",),
@@ -81,7 +87,6 @@ class SceneObjectDisplayUI(html.Div):
             VolumeDisplayUI(
                 obj_display="display",
                 obj_subtype=f"{self.obj}.object_subtype",
-                disabled=disabled,
                 is_primary=is_primary,
                 twod_presets=color_presets,
                 threed_presets=volume_presets,

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
@@ -17,7 +17,7 @@ class VolumeDisplayUI(html.Div):
         self,
         obj_display: str,
         obj_subtype: str,
-        has_opacity: str,
+        is_primary: str,
         twod_presets: str,
         threed_presets: str,
         **kwargs,
@@ -27,7 +27,7 @@ class VolumeDisplayUI(html.Div):
         )
         self.display = obj_display
         self.subtype = obj_subtype
-        self.has_opacity = has_opacity
+        self.is_primary = is_primary
         self.twod_presets = twod_presets
         self.threed_presets = threed_presets
         self._build_ui()
@@ -35,15 +35,16 @@ class VolumeDisplayUI(html.Div):
     def _build_ui(self) -> None:
         with self:
             with html.Div(v_if=(self._is_volume_subtype(SceneObjectSubtype.SCALAR),)):
-                VolumeDisplayThreeDColorUI(self.display, self.threed_presets)
-                v3.VDivider(classes="display-property-divider")
+                with html.Div(v_if=(self.is_primary,)):
+                    VolumeDisplayThreeDColorUI(self.display, self.threed_presets)
+                    v3.VDivider(classes="display-property-divider")
                 VolumeDisplayTwoDColorUI(self.display, self.twod_presets)
 
             with html.Div(v_if=(self._is_volume_subtype(SceneObjectSubtype.VECTOR),)):
                 VolumeDisplayNormalColorUI(self.display)
 
             with html.Div(
-                v_if=(self.has_opacity,),
+                v_if=(f"!{self.is_primary}",),
             ):
                 v3.VDivider(
                     v_if=(f"!{self._is_volume_subtype(SceneObjectSubtype.LABELMAP)}",),
@@ -52,7 +53,7 @@ class VolumeDisplayUI(html.Div):
                 ObjectDisplayOpacityUI(obj_opacity=f"{self.display}.opacity")
 
     def _is_volume_subtype(self, subtype: SceneObjectSubtype) -> str:
-        return f"{self.subtype} === '{subtype.value}'"
+        return f"({self.subtype} === '{subtype.value}')"
 
 
 class MeshDisplayUI(html.Div):
@@ -72,15 +73,27 @@ class MeshDisplayUI(html.Div):
 
 
 class SceneObjectDisplayUI(html.Div):
+<<<<<<< HEAD
     def __init__(self, obj: str, disabled: str, has_opacity: str, color_presets: str, volume_presets: str, **kwargs):
         super().__init__(classes=(f"{disabled} ? 'disabled' : ''",), **kwargs)
+=======
+    def __init__(self, obj: str, disabled: str, is_primary: str, color_presets: str, volume_presets: str, **kwargs):
+        super().__init__(
+            **kwargs,
+        )
+>>>>>>> 18735d6 (fix: block 3d preset edition for secondary volumes)
         self.obj = obj
 
         with self, Provider(name="display", instance=(f"{self.obj}.display",)):
             VolumeDisplayUI(
                 obj_display="display",
                 obj_subtype=f"{self.obj}.object_subtype",
+<<<<<<< HEAD
                 has_opacity=has_opacity,
+=======
+                disabled=disabled,
+                is_primary=is_primary,
+>>>>>>> 18735d6 (fix: block 3d preset edition for secondary volumes)
                 twod_presets=color_presets,
                 threed_presets=volume_presets,
                 v_if=(self._is_object_type(SceneObjectType.VOLUME),),
@@ -92,4 +105,4 @@ class SceneObjectDisplayUI(html.Div):
             )
 
     def _is_object_type(self, object_type: SceneObjectType) -> str:
-        return f"{self.obj}.object_type == '{object_type.value}'"
+        return f"({self.obj}.object_type == '{object_type.value}')"

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
@@ -73,27 +73,16 @@ class MeshDisplayUI(html.Div):
 
 
 class SceneObjectDisplayUI(html.Div):
-<<<<<<< HEAD
-    def __init__(self, obj: str, disabled: str, has_opacity: str, color_presets: str, volume_presets: str, **kwargs):
-        super().__init__(classes=(f"{disabled} ? 'disabled' : ''",), **kwargs)
-=======
     def __init__(self, obj: str, disabled: str, is_primary: str, color_presets: str, volume_presets: str, **kwargs):
-        super().__init__(
-            **kwargs,
-        )
->>>>>>> 18735d6 (fix: block 3d preset edition for secondary volumes)
+        super().__init__(classes=(f"{disabled} ? 'disabled' : ''",), **kwargs)
         self.obj = obj
 
         with self, Provider(name="display", instance=(f"{self.obj}.display",)):
             VolumeDisplayUI(
                 obj_display="display",
                 obj_subtype=f"{self.obj}.object_subtype",
-<<<<<<< HEAD
-                has_opacity=has_opacity,
-=======
                 disabled=disabled,
                 is_primary=is_primary,
->>>>>>> 18735d6 (fix: block 3d preset edition for secondary volumes)
                 twod_presets=color_presets,
                 threed_presets=volume_presets,
                 v_if=(self._is_object_type(SceneObjectType.VOLUME),),

--- a/girdermedviewer/app/widgets/ui/scene/scene_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/scene_ui.py
@@ -158,7 +158,7 @@ class SceneObjectUI(v3.VExpansionPanel):
                         SceneObjectDisplayUI(
                             obj=self._obj,
                             disabled=self._is_disabled(),
-                            has_opacity=f"!{self._is_primary_volume()}",
+                            is_primary=self._is_primary_volume(),
                             color_presets=f"{self._scene}.color_presets",
                             volume_presets=f"{self._scene}.volume_presets",
                         )

--- a/girdermedviewer/app/widgets/ui/scene/scene_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/scene_ui.py
@@ -59,15 +59,15 @@ class SceneObjectUI(v3.VExpansionPanel):
 
     def _build_ui(self):
         with self:
-            with v3.VExpansionPanelTitle(classes="item-card-title", v_if=(f"{self._obj}.gui.loading",)):
+            with v3.VExpansionPanelTitle(v_if=(f"{self._obj}.gui.loading",), classes="item-card-title"):
                 Text("{{ " + self._obj + ".name }}", classes="text-header font-weight-medium")
                 with v3.Template(v_slot_actions="{ expanded }"):
                     LoadingButton(
-                        tooltip="Cancel",
                         click_stop=(self.load_canceled, f"[{self._obj}._id]"),
+                        tooltip="Cancel",
                     )
 
-            with v3.VExpansionPanelTitle(classes="item-card-title", v_else=True):
+            with v3.VExpansionPanelTitle(v_else=True, classes="item-card-title"):
                 v3.VIcon(
                     icon=(f"{self._obj}.gui.icon",),
                     color=(f"{self._is_active_labelmap()} ? 'primary' : 'undefined'",),
@@ -220,10 +220,9 @@ class SceneUI(html.Div):
         with self, self._scene.provide_as("scene"):
             with v3.VExpansionPanels(
                 v_if=("scene.objects?.length > 0",),
-                v_model=("scene.gui.expanded_objects",),
+                v_model=("scene.gui.expanded_object",),
                 variant="accordion",
                 focusable=True,
-                multiple=True,
             ):
                 self.object_ui = SceneObjectUI(
                     obj="obj",

--- a/girdermedviewer/app/widgets/ui/scene/scene_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/scene_ui.py
@@ -64,6 +64,7 @@ class SceneObjectUI(v3.VExpansionPanel):
                 with v3.Template(v_slot_actions="{ expanded }"):
                     LoadingButton(
                         click_stop=(self.load_canceled, f"[{self._obj}._id]"),
+                        size="small",
                         tooltip="Cancel",
                     )
 
@@ -82,6 +83,7 @@ class SceneObjectUI(v3.VExpansionPanel):
                     Button(
                         click_stop=(self.visibility_clicked, f"[{self._obj}._id]"),
                         icon=(f"{self._obj}.is_visible ? 'mdi-eye-outline' : 'mdi-eye-off-outline'",),
+                        size="small",
                         tooltip=(f"{self._obj}.is_visible ? 'Hide' : 'Show'",),
                     )
 
@@ -142,7 +144,7 @@ class SceneObjectUI(v3.VExpansionPanel):
 
                 with (
                     v3.VCardText(),
-                    v3.VWindow(v_model=(f"{self._obj}.gui.current_window",), style="overflow: unset;"),
+                    v3.VWindow(v_model=(f"{self._obj}.gui.current_window"), style="overflow: unset;"),
                 ):
                     with (
                         v3.VWindowItem(value="filter", v_if=(f"{self._obj}.filter_type",)),

--- a/girdermedviewer/app/widgets/ui/vtk/tool_ui.py
+++ b/girdermedviewer/app/widgets/ui/vtk/tool_ui.py
@@ -88,7 +88,6 @@ class ToolUI(html.Div):
             if is_colored
             else None,
             disabled=(self._views_state.name.is_viewer_disabled,),
-            size="default",
             **kwargs,
         )
 

--- a/girdermedviewer/app/widgets/ui/vtk/tools/place_roi_ui.py
+++ b/girdermedviewer/app/widgets/ui/vtk/tools/place_roi_ui.py
@@ -37,9 +37,8 @@ class PlaceROIUI(v3.VCard):
                 disabled=(self._typed_state.name.is_roi_locked,),
             ):
                 Button(
-                    active=(self._typed_state.name.is_roi_locked,),
                     click=self._toggle_roi_interaction,
-                    icon="mdi-lock",
+                    icon=(f"{self._typed_state.name.is_roi_locked} ? 'mdi-lock' : 'mdi-lock-open'",),
                     tooltip=(f"{self._typed_state.name.is_roi_locked} ? 'Unlock' : 'Lock'",),
                 )
             with PointSelectorUI(

--- a/girdermedviewer/app/widgets/ui/vtk/tools/segmentation_effect_ui.py
+++ b/girdermedviewer/app/widgets/ui/vtk/tools/segmentation_effect_ui.py
@@ -31,6 +31,7 @@ class PaintEraseEffectUI(html.Div):
                     tooltip="Sphere brush",
                     click=f"{self._paint_erase_prop}.use_sphere_brush = !{self._paint_erase_prop}.use_sphere_brush",
                     active=(f"{self._paint_erase_prop}.use_sphere_brush",),
+                    size="small",
                 )
 
 

--- a/girdermedviewer/app/widgets/utils/components_utils.py
+++ b/girdermedviewer/app/widgets/utils/components_utils.py
@@ -51,6 +51,7 @@ class Button(VBtn):
         elif icon:
             kwargs["icon"] = True
             kwargs["variant"] = kwargs.get("variant", "text")
+            kwargs["size"] = kwargs.get("size", "small")
         else:
             kwargs["rounded"] = True
             kwargs["color"] = color
@@ -182,16 +183,17 @@ class Selector(VSelect):
 class GlobalStyle(Style):
     def __init__(self):
         super().__init__(
+            ".disabled { pointer-events: none; opacity: 0.5; } "
             ".display-property { gap: 12px; display: flex; flex-direction: column; } "
             ".display-property-divider { margin-top: 12px; margin-bottom: 12px; } "
             ".display-property-setting { gap: 12px; display: flex; flex-direction: row; align-items: center; } "
             ".disabled { pointer-events: none; opacity: 0.5; } "
-            ".drawer .v-navigation-drawer__content { display: flex; flex-direction: column; padding: 12px; justify-content: space-between;} "
+            ".drawer .v-navigation-drawer__content { display: flex; flex-direction: column; justify-content: space-between;} "
             ".fullscreen-view { position: relative; width: 100% !important; height: 100% !important; }"
             ".girder-browser { width: 100%; } "
-            ".item-card .v-expansion-panel--active>.v-expansion-panel-title,.v-expansion-panel-title { height: 64px !important }"
+            "html { overflow-y: hidden; } "
+            ".item-card-title { gap: 16px; padding: 12px; } "
             ".item-card .v-expansion-panel-text__wrapper { padding: 0 !important; }"
-            ".item-card-title { gap: 16px; } "
             ".layer-btn { position: relative; height: 24px; width: 24px; transform: rotateX(45deg); } "
             ".layer-bottom { position: absolute; top: 4px; left: -1px; } "
             ".layer-top { position: absolute; top: -4px; left: -1px; } "
@@ -206,13 +208,14 @@ class GlobalStyle(Style):
             ".position-selector .v-input__details { display: none !important; } "
             ".position-selector .v-text-field__prefix { font-weight: 700 !important; } "
             ".quad-view { display: flex; gap: 2px; width: 100%; height: 100%; flex-direction: row; flex-wrap: wrap; }"
-            ".scene-drawer { overflow: auto; } "
+            ".scene-drawer { padding-left: 16px; padding-top: 16px; padding-bottom: 16px; overflow: auto; scrollbar-gutter: stable; } "
             ".segment-item .v-list-item__prepend { display: grid; }"
             ".text-header { font-size: 1.125rem; font-weight: 300; line-height: 1.75; letter-spacing: 0.0125em; }"
             ".text-subtitle { font-size: 1rem; font-weight: 500; line-height: 1.75; letter-spacing:  0.009375em; }"
+            ".tool-card { padding: 16px; }"
             ".tool-card .v-card-text { padding: 0px; }"
             ".tool-card .v-card-title { display: flex; justify-content: space-between; align-items: center; }"
-            ".tools-strip { display: flex; flex-direction: column; align-items: center; width: 50px; }"
+            ".tools-strip { display: flex; flex-direction: column; align-items: center; width: 100%; }"
             ".v-btn-group .v-btn:first-child { border-end-start-radius: 24px; border-start-start-radius: 24px; } "
             ".v-btn-group .v-btn:last-child { border-start-end-radius: 24px; border-end-end-radius: 24px; } "
             ".v-window { overflow: unset; } "

--- a/girdermedviewer/app/widgets/utils/components_utils.py
+++ b/girdermedviewer/app/widgets/utils/components_utils.py
@@ -176,7 +176,7 @@ class RangeSlider(VRangeSlider):
 
 class Selector(VSelect):
     def __init__(self, **kwargs):
-        super().__init__(flat=True, hide_details=True, variant="solo-filled", density="comfortable", **kwargs)
+        super().__init__(flat=True, hide_details=True, variant="solo-filled", density="compact", **kwargs)
 
 
 class GlobalStyle(Style):

--- a/girdermedviewer/app/widgets/utils/components_utils.py
+++ b/girdermedviewer/app/widgets/utils/components_utils.py
@@ -51,7 +51,6 @@ class Button(VBtn):
         elif icon:
             kwargs["icon"] = True
             kwargs["variant"] = kwargs.get("variant", "text")
-            kwargs["size"] = kwargs.get("size", "small")
         else:
             kwargs["rounded"] = True
             kwargs["color"] = color
@@ -192,7 +191,7 @@ class GlobalStyle(Style):
             ".fullscreen-view { position: relative; width: 100% !important; height: 100% !important; }"
             ".girder-browser { width: 100%; } "
             "html { overflow-y: hidden; } "
-            ".item-card-title { gap: 16px; padding: 12px; } "
+            ".item-card-title { gap: 16px; padding: 12px; height: 64px; } "
             ".item-card .v-expansion-panel-text__wrapper { padding: 0 !important; }"
             ".layer-btn { position: relative; height: 24px; width: 24px; transform: rotateX(45deg); } "
             ".layer-bottom { position: absolute; top: 4px; left: -1px; } "


### PR DESCRIPTION
- **Disable 3d preset for secondary volumes** ⚠️ will be rolled back when reactivating volume rendering for secondary volumes
- **Fixes scrollbar issues**: scrollbar in drawer does not shift other components to the left anymore, document scrollbar removed
- **Rework state and trame-dataclass state flushes**
- **Disable UI with CSS at parent component level rather than passing an argument to every child component**
- **Chore:** clean bits of code, always give object subtype  (labelmap, vectors, scalar) to render them
