### PR TITLE
fix(visibility): fix visibility conflict for RGB volumes

### DIFF
--- a/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
@@ -99,7 +99,7 @@ class MeshHandler(ObjectHandler):
             ("name", "is_inverted", "array_range"),
             self._display_handler.update_array_coloring(mesh_logic),
         )
-        mesh_logic.scene_object.watch(("is_visible",), self._display_handler.update_visibility(mesh_logic))
+        mesh_logic.display.watch(("is_visible",), self._display_handler.update_visibility(mesh_logic))
 
     def add_object_to_views(self, mesh_logic: MeshObjectLogic) -> None:
         self.object_logics[mesh_logic._id] = mesh_logic

--- a/girdermedviewer/app/widgets/logic/scene/handlers/object_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/object_handler.py
@@ -39,4 +39,4 @@ class ObjectHandler(BaseLogic[SceneState]):
         pass
 
     def set_object_visibility(self, object_logic: SceneObjectLogic, visible: bool) -> None:
-        object_logic.scene_object.is_visible = visible
+        object_logic.display.is_visible = visible

--- a/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
@@ -107,7 +107,7 @@ class SegmentationHandler(ObjectHandler):
 
     def _connect_labelmap_to_display_handler(self, seg_filter_logic: SegmentationFilterLogic):
         seg_filter_logic.display.watch(("opacity",), self._display_handler.update_opacity(seg_filter_logic))
-        seg_filter_logic.scene_object.watch(("is_visible",), self._display_handler.update_visibility(seg_filter_logic))
+        seg_filter_logic.display.watch(("is_visible",), self._display_handler.update_visibility(seg_filter_logic))
 
     def select_segment_in_labelmap(
         self, seg_filter_logic: SegmentationFilterLogic | None, segment_id: str | None = None

--- a/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
@@ -17,19 +17,11 @@ class VolumeDisplayHandler:
 
     def update_visibility(self, volume_logic: VolumeObjectLogic, visible: bool) -> None:
         volume_logic.scene_object.is_visible = visible
+        update_glyph = volume_logic.display.normal_color is not None and volume_logic.display.normal_color.show_arrows
         for view in self.views_logic.views:
-            modified = view.volume_handler.set_volume_visibility(volume_logic._id, visible)
+            modified = view.volume_handler.set_volume_visibility(volume_logic._id, visible, update_glyph)
             if modified:
                 view.update()
-
-    def update_threed_visibility(self, volume_logic: VolumeObjectLogic) -> Callable:
-        def _update_threed_visibility(visible: bool) -> None:
-            for view in self.views_logic.threed_views:
-                modified = view.volume_handler.set_volume_visibility(volume_logic._id, visible)
-                if modified:
-                    view.update()
-
-        return _update_threed_visibility
 
     def update_opacity(self, volume_logic: VolumeObjectLogic) -> Callable:
         @debounce(0.05)
@@ -78,18 +70,9 @@ class VolumeDisplayHandler:
         def _update_normal_coloring(show_arrows: bool, sampling: int, arrow_length: float, arrow_width: float) -> None:
             if not volume_logic.is_visible:
                 return
-            for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_volume_normal_color(
-                    volume_logic._id,
-                    show_arrows,
-                    sampling,
-                    arrow_length,
-                    arrow_width,
-                    view.orientation.value,
-                )
-                if modified:
-                    view.update()
-            for view in self.views_logic.threed_views:
+
+            for view in self.views_logic.views:
+                view.volume_handler.set_volume_visibility(volume_logic._id, not show_arrows)
                 modified = view.volume_handler.set_volume_normal_color(
                     volume_logic._id,
                     show_arrows,
@@ -170,19 +153,19 @@ class VolumeHandler(ObjectHandler):
     def _connect_volume_to_display_handler(self, volume_logic: VolumeObjectLogic):
         volume_logic.display.watch(("opacity",), self._display_handler.update_opacity(volume_logic))
         volume_logic.display.watch(("window_level",), self._display_handler.update_window_level(volume_logic))
-        volume_logic.display.threed_color.watch(
-            ("name", "vr_shift"), self._display_handler.update_threed_coloring(volume_logic)
-        )
-        if volume_logic.display.twod_color is not None:
-            volume_logic.display.twod_color.watch(
-                ("name", "is_inverted"), self._display_handler.update_twod_coloring(volume_logic)
-            )
-        elif volume_logic.display.normal_color is not None:
+
+        if volume_logic.display.normal_color is not None:
             volume_logic.display.normal_color.watch(
                 ("show_arrows", "sampling", "arrow_length", "arrow_width"),
                 self._display_handler.update_normal_coloring(volume_logic),
             )
-        volume_logic.scene_object.watch(("is_visible",), self._display_handler.update_threed_visibility(volume_logic))
+        else:
+            volume_logic.display.threed_color.watch(
+                ("name", "vr_shift"), self._display_handler.update_threed_coloring(volume_logic)
+            )
+            volume_logic.display.twod_color.watch(
+                ("name", "is_inverted"), self._display_handler.update_twod_coloring(volume_logic)
+            )
         volume_logic.updated.connect(self.views_logic.update_views)
 
     def _add_volume_to_views(self, volume_logic: VolumeObjectLogic, layer: VolumeLayer) -> None:

--- a/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
@@ -16,10 +16,9 @@ class VolumeDisplayHandler:
         self.views_logic = views_logic
 
     def update_visibility(self, volume_logic: VolumeObjectLogic, visible: bool) -> None:
-        volume_logic.scene_object.is_visible = visible
-        update_glyph = volume_logic.display.normal_color is not None and volume_logic.display.normal_color.show_arrows
+        volume_logic.display.is_visible = visible
         for view in self.views_logic.views:
-            modified = view.volume_handler.set_volume_visibility(volume_logic._id, visible, update_glyph)
+            modified = view.volume_handler.set_volume_visibility(volume_logic._id, visible)
             if modified:
                 view.update()
 
@@ -135,13 +134,14 @@ class VolumeHandler(ObjectHandler):
     def _set_active_primary_volume_id(self, volume_id: str | None) -> None:
         if self.active_primary_volume_id is not None:
             old_active = self.object_logics.get(self.active_primary_volume_id)
-            if old_active is not None:
+            if old_active is not None and old_active.is_visible:
                 self._display_handler.update_visibility(old_active, False)
 
         self.data.active_primary_volume_id = volume_id
         if self.active_primary_volume_id is not None:
             new_active = self.object_logics.get(self.active_primary_volume_id)
-            self._display_handler.update_visibility(new_active, True)
+            if not new_active.is_visible:
+                self._display_handler.update_visibility(new_active, True)
 
     def _add_to_primary_volumes(self, volume_id: str) -> None:
         if not self._is_primary_volume(volume_id):

--- a/girdermedviewer/app/widgets/logic/scene/objects/mesh_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/mesh_object_logic.py
@@ -1,6 +1,6 @@
 import logging
 
-from trame_dataclass.v2 import StateDataModel, Sync, TypeValidation
+from trame_dataclass.v2 import StateDataModel, Sync
 
 from ....utils import (
     DataArray,
@@ -9,7 +9,7 @@ from ....utils import (
     get_random_color,
     load_mesh,
 )
-from .scene_object_logic import SceneObjectLogic, TwoDColor
+from .scene_object_logic import SceneObjectDisplay, SceneObjectLogic, TwoDColor
 
 logger = logging.getLogger(__name__)
 
@@ -20,12 +20,11 @@ class ArrayColor(StateDataModel):
     array_range = Sync(list[float], list)
 
 
-class MeshDisplay(StateDataModel):
+class MeshDisplay(SceneObjectDisplay):
     data_arrays = Sync(list[DataArray], list, has_dataclass=True)
     active_array_id = Sync(str)
     solid_color = Sync(str)
     array_color = Sync(ArrayColor, has_dataclass=True)
-    opacity = Sync(float, 1.0, type_checking=TypeValidation.SKIP)
 
 
 class MeshObjectLogic(SceneObjectLogic):

--- a/girdermedviewer/app/widgets/logic/scene/objects/scene_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/scene_object_logic.py
@@ -6,6 +6,7 @@ from trame_dataclass.v2 import (
     FieldEncoder,
     StateDataModel,
     Sync,
+    TypeValidation,
 )
 from trame_server import Server
 from undo_stack import Signal
@@ -46,6 +47,11 @@ class SceneObjectGUI(StateDataModel):
     icon = Sync(str)
 
 
+class SceneObjectDisplay(StateDataModel):
+    opacity = Sync(float, 1.0, type_checking=TypeValidation.SKIP)
+    is_visible = Sync(bool, True)
+
+
 class SceneObject(StateDataModel):
     name = Sync(str)
     gui = Sync(SceneObjectGUI, has_dataclass=True)
@@ -69,7 +75,6 @@ class SceneObject(StateDataModel):
         convert=FieldEncoder(FilterType.encoder, FilterType.decoder),
     )
     filter_prop_id = Sync(str)
-    is_visible = Sync(bool, True)
 
 
 class SceneObjectLogic(BaseLogic[None]):
@@ -85,6 +90,7 @@ class SceneObjectLogic(BaseLogic[None]):
     """
 
     updated = Signal()
+    display: SceneObjectDisplay
 
     def __init__(
         self,
@@ -100,7 +106,7 @@ class SceneObjectLogic(BaseLogic[None]):
 
     @property
     def is_visible(self) -> bool:
-        return self.scene_object.is_visible
+        return self.display.is_visible
 
     @abstractmethod
     def load_object_data(self, *args, **kwargs):

--- a/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
@@ -12,7 +12,12 @@ from ....utils import (
     VolumeLayer,
     load_volume,
 )
-from .scene_object_logic import SceneObjectLogic, ThreeDColor, TwoDColor
+from .scene_object_logic import (
+    SceneObjectDisplay,
+    SceneObjectLogic,
+    ThreeDColor,
+    TwoDColor,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -24,13 +29,12 @@ class NormalColor(StateDataModel):
     arrow_width = Sync(float, 0.03, type_checking=TypeValidation.SKIP)
 
 
-class VolumeDisplay(StateDataModel):
+class VolumeDisplay(SceneObjectDisplay):
     scalar_range = Sync(list[float])
     window_level = Sync(list[float])
     threed_color = Sync(ThreeDColor, has_dataclass=True)
     twod_color = Sync(TwoDColor, has_dataclass=True)
     normal_color = Sync(NormalColor, has_dataclass=True)
-    opacity = Sync(float, 0.5, type_checking=TypeValidation.SKIP)  # Used only for secondary volumes
 
 
 class BaseVolumeObjectLogic(SceneObjectLogic):
@@ -42,6 +46,7 @@ class BaseVolumeObjectLogic(SceneObjectLogic):
         self.scene_object.object_type = SceneObjectType.VOLUME
         self.display = VolumeDisplay(
             self.server,
+            opacity=0.5,  # Used only for secondary volumes
         )
         self.scene_object.display = self.display._id
         self.scene_object.flush()

--- a/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
@@ -46,30 +46,31 @@ class BaseVolumeObjectLogic(SceneObjectLogic):
         self.scene_object.display = self.display._id
         self.scene_object.flush()
 
+
 class VolumeObjectLogic(BaseVolumeObjectLogic):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.scene_object.object_type = SceneObjectType.VOLUME
-        self.display.threed_color = ThreeDColor(self.server)
         self.scalar_range: list[float] = []
 
     def _init_display_properties(self):
         if self.object_data is not None:
+            self.scalar_range = list(self.object_data.GetScalarRange())
+            self.display.twod_color = TwoDColor(self.server)
+            self.display.threed_color = ThreeDColor(self.server, vr_shift=self.scalar_range)
+
             # Init volume type
             if self.object_data.GetPointData().GetScalars().GetNumberOfComponents() > 1:
                 self.scene_object.object_subtype = SceneObjectSubtype.VECTOR
                 self.display.normal_color = NormalColor(self.server)
             else:
                 self.scene_object.object_subtype = SceneObjectSubtype.SCALAR
-                self.display.twod_color = TwoDColor(self.server)
 
-            self.scalar_range = list(self.object_data.GetScalarRange())
             # Init window level
             self.display.scalar_range = self.scalar_range
             # Init window level
             self.display.window_level = self.scalar_range
-            # Init 3D preset range
-            self.display.threed_color.vr_shift = self.scalar_range
+
     def load_object_data(self, file_path: str) -> None:
         self.object_data = load_volume(file_path)
         self._init_display_properties()

--- a/girdermedviewer/app/widgets/logic/scene/scene_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/scene_logic.py
@@ -203,9 +203,7 @@ class SceneLogic(BaseLogic[SceneState]):
         if object_logic is None:
             return
 
-        self._get_object_handler(object_logic).set_object_visibility(
-            object_logic, not object_logic.scene_object.is_visible
-        )
+        self._get_object_handler(object_logic).set_object_visibility(object_logic, not object_logic.is_visible)
 
     def toggle_object_overlay(self, object_id: str) -> None:
         object_logic = self.object_logics.get(object_id)

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
@@ -26,6 +26,8 @@ class MeshHandler(ObjectHandler):
         self.preset_parser = preset_parser
 
     def apply_mesh_display_properties(self, data_id: str, display_properties: MeshDisplay) -> None:
+        self.register_display(data_id, display_properties)
+
         # Set opacity
         self.set_mesh_opacity(data_id, display_properties.opacity)
 
@@ -43,6 +45,9 @@ class MeshHandler(ObjectHandler):
                 display_properties.array_color.is_inverted,
                 display_properties.array_color.array_range,
             )
+
+        # Set visibility
+        self.set_mesh_visibility(data_id, display_properties.is_visible)
 
     def add_mesh_in_3D(self, data_id: str, poly_data: vtkPolyData) -> None:
         actor = render_mesh_in_3D(poly_data, self.renderer)

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
@@ -4,6 +4,10 @@ from typing import Any
 
 from vtkmodules.vtkRenderingCore import vtkRenderer
 
+from girdermedviewer.app.widgets.logic.scene.objects.scene_object_logic import (
+    SceneObjectDisplay,
+)
+
 from ....utils import (
     get_image_data,
     remove_prop,
@@ -15,6 +19,7 @@ logger = logging.getLogger(__name__)
 class ObjectHandler:
     def __init__(self) -> None:
         self.object_data = defaultdict(list)
+        self.object_display = defaultdict(list)
         self.renderer: vtkRenderer | None = None
 
     def set_renderer(self, renderer: vtkRenderer) -> None:
@@ -22,6 +27,9 @@ class ObjectHandler:
 
     def register_data(self, data_id: str, data: Any) -> None:
         self.object_data[data_id].append(data)
+
+    def register_display(self, data_id: str, display: SceneObjectDisplay) -> None:
+        self.object_display[data_id] = display
 
     def unregister_data(self, data_id, only_data=None, remove=True):
         objects = self.object_data.get(data_id)
@@ -37,10 +45,14 @@ class ObjectHandler:
 
         if not self.object_data[data_id]:
             self.object_data.pop(data_id)
+            self.object_display.pop(data_id)
 
     def get_data(self, data_id):
         data = self.object_data.get(data_id, [])
         return data[0] if len(data) else None
+
+    def get_display(self, data_id: str) -> SceneObjectDisplay:
+        return self.object_display.get(data_id)
 
     def get_actors(self, data_id):
         data = [self.object_data[data_id]] if data_id in self.object_data else self.object_data.values()
@@ -53,4 +65,9 @@ class ObjectHandler:
 
     def get_glyph_actors(self, data_id):
         data = [self.object_data[data_id]] if data_id in self.object_data else self.object_data.values()
-        return [obj for objs in data for obj in objs if hasattr(obj, 'GetMapper') and obj.GetMapper().IsA("vtkGlyph3DMapper")]
+        return [
+            obj
+            for objs in data
+            for obj in objs
+            if hasattr(obj, "GetMapper") and obj.GetMapper().IsA("vtkGlyph3DMapper")
+        ]

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -10,6 +10,7 @@ from vtk import (
 
 from ....utils import (
     ColorPresetParser,
+    PresetParser,
     VolumePresetParser,
     convert_color_hex_to_normalized_rgb,
     render_labelmap_as_overlay_in_slice,
@@ -38,34 +39,15 @@ logger = logging.getLogger(__name__)
 
 
 class VolumeHandler(ObjectHandler):
-    def __init__(self, preset_parser: ColorPresetParser, orientation: int | None = None):
+    def __init__(self, preset_parser: PresetParser):
         super().__init__()
         self.preset_parser = preset_parser
-        self.orientation = orientation
 
     @abstractmethod
-    def _set_volume_visibility(self, data_id: str, visible: bool) -> bool:
+    def set_volume_visibility(self, data_id: str, visible: bool) -> bool:
         pass
 
-    def _init_glyph_actors(self, data_id: str) -> None:
-        volume = self.get_data(data_id)
-        if volume is None:
-            return
-        glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer, self.orientation)
-        self.register_data(data_id, glyph_actor)
-
-    def _set_glyph_actors_visibility(self, data_id: str, visible: bool) -> bool:
-        logger.debug(f"set_glyph_actors_visibility({data_id}): {visible}")
-        modified = False
-        for glyph_actor in self.get_glyph_actors(data_id):
-            modified = set_actor_visibility(glyph_actor, visible) or modified
-        return modified
-
-    def set_volume_visibility(self, data_id: str, visible: bool, update_glyph: bool = False) -> bool:
-        if update_glyph:
-            return self._set_glyph_actors_visibility(data_id, visible)
-        return self._set_volume_visibility(data_id, visible)
-
+    @abstractmethod
     def set_volume_normal_color(
         self,
         data_id: str,
@@ -74,20 +56,13 @@ class VolumeHandler(ObjectHandler):
         arrow_length: float,
         arrow_width: float,
     ) -> bool:
-        logger.debug(f"set_volume_normal_color({data_id})")
-        modified = False
-        for glyph_actor in self.get_glyph_actors(data_id):
-            modified = set_actor_visibility(glyph_actor, show_arrows) or modified
-            modified = set_vector_field_sampling(glyph_actor, self.orientation, sampling) or modified
-            modified = set_vector_field_arrow_length(glyph_actor, arrow_length) or modified
-            modified = set_vector_field_arrow_thickness(glyph_actor, arrow_width) or modified
-
-        return modified
+        pass
 
 
 class VolumeSliceHandler(VolumeHandler):
     def __init__(self, preset_parser: ColorPresetParser, orientation: int) -> None:
-        super().__init__(preset_parser, orientation)
+        super().__init__(preset_parser)
+        self.orientation = orientation
 
     def _is_primary_volume(self, data_id: str) -> bool:
         data = self.get_data(data_id)
@@ -100,6 +75,10 @@ class VolumeSliceHandler(VolumeHandler):
     def _has_multiple_primary_volumes(self) -> bool:
         return len([data_id for data_id in self.object_data if self._is_primary_volume(data_id)]) > 1
 
+    def _init_glyph_actors(self, data_id: str) -> None:
+        glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer, self.orientation)
+        self.register_data(data_id, glyph_actor)
+
     def has_primary_volume(self) -> bool:
         return self.get_reslice_image_viewer() is not None
 
@@ -111,27 +90,38 @@ class VolumeSliceHandler(VolumeHandler):
         remove_prop = not (self._is_primary_volume(data_id) and self._has_multiple_primary_volumes())
         super().unregister_data(data_id, only_data, remove_prop)
 
-    def apply_volume_display_properties(self, data_id: str, display_property: VolumeDisplay, is_primary: bool) -> None:
-        self.set_volume_window_level_min_max(data_id, display_property.window_level)
-        if is_primary:
+    def apply_volume_display_properties(
+        self, data_id: str, display_properties: VolumeDisplay, is_primary: bool
+    ) -> None:
+        self.register_display(data_id, display_properties)
+        self.set_volume_window_level_min_max(data_id, display_properties.window_level)
+
+        # Set opacity
+        if not is_primary:
+            self.set_volume_opacity(data_id, display_properties.opacity)
+
+        # Set color
+        else:
+            # FIXME: supposed to be set for secondary volumes also
             self.set_volume_scalar_color_preset(
                 data_id,
-                display_property.twod_color.name,
-                display_property.twod_color.is_inverted,
+                display_properties.twod_color.name,
+                display_properties.twod_color.is_inverted,
             )
-        else:
-            self.set_volume_opacity(data_id, display_property.opacity)
 
-        if display_property.normal_color is not None:
-            self._set_volume_visibility(data_id, not display_property.normal_color.show_arrows)
-            self._init_glyph_actors(data_id)
+        if display_properties.normal_color is not None:
+            if not self.get_glyph_actors(data_id):
+                self._init_glyph_actors(data_id)
             self.set_volume_normal_color(
                 data_id,
-                display_property.normal_color.show_arrows,
-                display_property.normal_color.sampling,
-                display_property.normal_color.arrow_length,
-                display_property.normal_color.arrow_width,
+                display_properties.normal_color.show_arrows,
+                display_properties.normal_color.sampling,
+                display_properties.normal_color.arrow_length,
+                display_properties.normal_color.arrow_width,
             )
+
+        # Set visibility
+        self.set_volume_visibility(data_id, display_properties.is_visible)
 
     def add_primary_volume(self, data_id: str, image_data: vtkImageData) -> None:
         reslice_image_viewer = render_volume_in_slice(image_data, self.renderer, self.orientation)
@@ -145,14 +135,22 @@ class VolumeSliceHandler(VolumeHandler):
         actor = render_labelmap_as_overlay_in_slice(image_data, axis=self.orientation)
         self.register_data(data_id, actor)
 
-    def _set_volume_visibility(self, data_id: str, visible: bool) -> bool:
+    def set_volume_visibility(self, data_id: str, visible: bool) -> bool:
         logger.debug(f"set_volume_visibility({data_id}): {visible}")
+        volume_display = self.get_display(data_id)
+        if volume_display is None:
+            return False
+        show_arrows = volume_display.normal_color is not None and volume_display.normal_color.show_arrows
+
         modified = False
         reslice_image_viewer = self.get_reslice_image_viewer(data_id)
         if reslice_image_viewer is not None:
-            modified = set_reslice_visibility(reslice_image_viewer, visible)
+            modified = set_reslice_visibility(reslice_image_viewer, visible and not show_arrows)
         for slice in self.get_image_slices(data_id):
-            modified = set_slice_visibility(slice, visible) or modified
+            modified = set_slice_visibility(slice, visible and not show_arrows) or modified
+        for glyph_actor in self.get_glyph_actors(data_id):
+            modified = set_actor_visibility(glyph_actor, visible and show_arrows) or modified
+
         return modified
 
     def set_volume_opacity(self, data_id: str, opacity: float) -> bool:
@@ -201,12 +199,27 @@ class VolumeSliceHandler(VolumeHandler):
             modified = self.preset_parser.apply_preset_to_volume(slice.GetProperty(), preset, is_inverted)
         return modified
 
-    def _init_glyph_actors(self, data_id: str) -> None:
-        volume = self.get_data(data_id)
-        if volume is None:
-            return
-        glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer, self.orientation)
-        self.register_data(data_id, glyph_actor)
+    def set_volume_normal_color(
+        self,
+        data_id: str,
+        show_arrows: bool,
+        sampling: int,
+        arrow_length: float,
+        arrow_width: float,
+    ) -> bool:
+        volume_display = self.get_display(data_id)
+        if volume_display is None:
+            return False
+
+        logger.debug(f"set_volume_normal_color({data_id})")
+        modified = False
+        for glyph_actor in self.get_glyph_actors(data_id):
+            modified = set_actor_visibility(glyph_actor, show_arrows and volume_display.is_visible) or modified
+            modified = set_vector_field_sampling(glyph_actor, sampling, self.orientation) or modified
+            modified = set_vector_field_arrow_length(glyph_actor, arrow_length) or modified
+            modified = set_vector_field_arrow_thickness(glyph_actor, arrow_width) or modified
+
+        return modified
 
     def get_reslice_image_viewer(self, data_id=None) -> vtkResliceImageViewer | None:
         """
@@ -239,34 +252,53 @@ class VolumeThreeDHandler(VolumeHandler):
     def __init__(self, preset_parser: VolumePresetParser) -> None:
         super().__init__(preset_parser)
 
-    def apply_volume_display_properties(self, data_id: str, display_property: VolumeDisplay) -> None:
-        if display_property.normal_color is not None:
-            self._set_volume_visibility(data_id, False)
-            self._init_glyph_actors(data_id)
+    def _init_glyph_actors(self, data_id: str) -> None:
+        glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer)
+        self.register_data(data_id, glyph_actor)
+
+    def apply_volume_display_properties(self, data_id: str, display_properties: VolumeDisplay) -> None:
+        self.register_display(data_id, display_properties)
+
+        # Set color
+        if display_properties.normal_color is not None:
+            if not self.get_glyph_actors(data_id):
+                self._init_glyph_actors(data_id)
             self.set_volume_normal_color(
                 data_id,
-                display_property.normal_color.show_arrows,
-                display_property.normal_color.sampling,
-                display_property.normal_color.arrow_length,
-                display_property.normal_color.arrow_width,
+                display_properties.normal_color.show_arrows,
+                display_properties.normal_color.sampling,
+                display_properties.normal_color.arrow_length,
+                display_properties.normal_color.arrow_width,
             )
         else:
             self.set_volume_preset(
                 data_id,
-                display_property.threed_color.name,
-                display_property.threed_color.vr_shift,
+                display_properties.threed_color.name,
+                display_properties.threed_color.vr_shift,
             )
+
+        # Set visibility
+        self.set_volume_visibility(data_id, display_properties.is_visible)
 
     def add_volume(self, data_id: str, image_data: vtkImageData) -> None:
         volume = render_volume_in_3D(image_data, self.renderer)
         self.register_data(data_id, volume)
 
-    def _set_volume_visibility(self, data_id: str, visible: bool) -> bool:
+    def set_volume_visibility(self, data_id: str, visible: bool) -> bool:
         logger.debug(f"set_volume_visibility({data_id}): {visible}")
         volume = self.get_data(data_id)
-        if volume is None or len(self.get_glyph_actors(data_id)) > 0:
+        if volume is None:
             return False
-        return set_volume_visibility(volume, visible)
+
+        volume_display = self.get_display(data_id)
+        if volume_display is None:
+            return False
+
+        modified = set_volume_visibility(volume, visible and volume_display.normal_color is None)
+        show_arrows = volume_display.normal_color is not None and volume_display.normal_color.show_arrows
+        for glyph_actor in self.get_glyph_actors(data_id):
+            modified = set_actor_visibility(glyph_actor, visible and show_arrows) or modified
+        return modified
 
     def set_volume_preset(self, data_id: str, preset_name: str, range: list[float]) -> bool:
         volume = self.get_data(data_id)
@@ -277,3 +309,25 @@ class VolumeThreeDHandler(VolumeHandler):
         if preset is None:
             return False
         return self.preset_parser.apply_preset(volume.GetProperty(), preset, range)
+
+    def set_volume_normal_color(
+        self,
+        data_id: str,
+        show_arrows: bool,
+        sampling: int,
+        arrow_length: float,
+        arrow_width: float,
+    ) -> bool:
+        volume_display = self.get_display(data_id)
+        if volume_display is None:
+            return False
+
+        logger.debug(f"set_volume_normal_color({data_id})")
+        modified = False
+        for glyph_actor in self.get_glyph_actors(data_id):
+            modified = set_actor_visibility(glyph_actor, show_arrows and volume_display.is_visible) or modified
+            modified = set_vector_field_sampling(glyph_actor, sampling) or modified
+            modified = set_vector_field_arrow_length(glyph_actor, arrow_length) or modified
+            modified = set_vector_field_arrow_thickness(glyph_actor, arrow_width) or modified
+
+        return modified

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -1,4 +1,5 @@
 import logging
+from abc import abstractmethod
 from typing import Any
 
 from vtk import (
@@ -36,10 +37,57 @@ from .object_handler import ObjectHandler
 logger = logging.getLogger(__name__)
 
 
-class VolumeSliceHandler(ObjectHandler):
-    def __init__(self, preset_parser: ColorPresetParser) -> None:
+class VolumeHandler(ObjectHandler):
+    def __init__(self, preset_parser: ColorPresetParser, orientation: int | None = None):
         super().__init__()
         self.preset_parser = preset_parser
+        self.orientation = orientation
+
+    @abstractmethod
+    def _set_volume_visibility(self, data_id: str, visible: bool) -> bool:
+        pass
+
+    def _init_glyph_actors(self, data_id: str) -> None:
+        volume = self.get_data(data_id)
+        if volume is None:
+            return
+        glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer, self.orientation)
+        self.register_data(data_id, glyph_actor)
+
+    def _set_glyph_actors_visibility(self, data_id: str, visible: bool) -> bool:
+        logger.debug(f"set_glyph_actors_visibility({data_id}): {visible}")
+        modified = False
+        for glyph_actor in self.get_glyph_actors(data_id):
+            modified = set_actor_visibility(glyph_actor, visible) or modified
+        return modified
+
+    def set_volume_visibility(self, data_id: str, visible: bool, update_glyph: bool = False) -> bool:
+        if update_glyph:
+            return self._set_glyph_actors_visibility(data_id, visible)
+        return self._set_volume_visibility(data_id, visible)
+
+    def set_volume_normal_color(
+        self,
+        data_id: str,
+        show_arrows: bool,
+        sampling: int,
+        arrow_length: float,
+        arrow_width: float,
+    ) -> bool:
+        logger.debug(f"set_volume_normal_color({data_id})")
+        modified = False
+        for glyph_actor in self.get_glyph_actors(data_id):
+            modified = set_actor_visibility(glyph_actor, show_arrows) or modified
+            modified = set_vector_field_sampling(glyph_actor, self.orientation, sampling) or modified
+            modified = set_vector_field_arrow_length(glyph_actor, arrow_length) or modified
+            modified = set_vector_field_arrow_thickness(glyph_actor, arrow_width) or modified
+
+        return modified
+
+
+class VolumeSliceHandler(VolumeHandler):
+    def __init__(self, preset_parser: ColorPresetParser, orientation: int) -> None:
+        super().__init__(preset_parser, orientation)
 
     def _is_primary_volume(self, data_id: str) -> bool:
         data = self.get_data(data_id)
@@ -63,41 +111,41 @@ class VolumeSliceHandler(ObjectHandler):
         remove_prop = not (self._is_primary_volume(data_id) and self._has_multiple_primary_volumes())
         super().unregister_data(data_id, only_data, remove_prop)
 
-    def apply_volume_display_properties(
-        self, data_id: str, display_property: VolumeDisplay, orientation: int, is_primary: bool
-    ) -> None:
+    def apply_volume_display_properties(self, data_id: str, display_property: VolumeDisplay, is_primary: bool) -> None:
         self.set_volume_window_level_min_max(data_id, display_property.window_level)
-        if not is_primary:
-            self.set_volume_opacity(data_id, display_property.opacity)
-        elif display_property.twod_color is not None:
+        if is_primary:
             self.set_volume_scalar_color_preset(
                 data_id,
                 display_property.twod_color.name,
                 display_property.twod_color.is_inverted,
             )
-        elif display_property.normal_color is not None:
+        else:
+            self.set_volume_opacity(data_id, display_property.opacity)
+
+        if display_property.normal_color is not None:
+            self._set_volume_visibility(data_id, not display_property.normal_color.show_arrows)
+            self._init_glyph_actors(data_id)
             self.set_volume_normal_color(
                 data_id,
                 display_property.normal_color.show_arrows,
                 display_property.normal_color.sampling,
                 display_property.normal_color.arrow_length,
                 display_property.normal_color.arrow_width,
-                orientation,
             )
 
-    def add_primary_volume(self, data_id: str, image_data: vtkImageData, orientation: int) -> None:
-        reslice_image_viewer = render_volume_in_slice(image_data, self.renderer, orientation)
+    def add_primary_volume(self, data_id: str, image_data: vtkImageData) -> None:
+        reslice_image_viewer = render_volume_in_slice(image_data, self.renderer, self.orientation)
         self.register_data(data_id, reslice_image_viewer)
 
-    def add_secondary_volume(self, data_id: str, image_data: vtkImageData, orientation: int):
-        actor = render_volume_as_overlay_in_slice(image_data, self.renderer, axis=orientation)
+    def add_secondary_volume(self, data_id: str, image_data: vtkImageData):
+        actor = render_volume_as_overlay_in_slice(image_data, self.renderer, axis=self.orientation)
         self.register_data(data_id, actor)
 
-    def add_labelmap(self, data_id: str, image_data: vtkImageData, orientation: int):
-        actor = render_labelmap_as_overlay_in_slice(image_data, axis=orientation)
+    def add_labelmap(self, data_id: str, image_data: vtkImageData):
+        actor = render_labelmap_as_overlay_in_slice(image_data, axis=self.orientation)
         self.register_data(data_id, actor)
 
-    def set_volume_visibility(self, data_id: str, visible: bool) -> bool:
+    def _set_volume_visibility(self, data_id: str, visible: bool) -> bool:
         logger.debug(f"set_volume_visibility({data_id}): {visible}")
         modified = False
         reslice_image_viewer = self.get_reslice_image_viewer(data_id)
@@ -105,8 +153,6 @@ class VolumeSliceHandler(ObjectHandler):
             modified = set_reslice_visibility(reslice_image_viewer, visible)
         for slice in self.get_image_slices(data_id):
             modified = set_slice_visibility(slice, visible) or modified
-        for glyph_actor in self.get_glyph_actors(data_id):
-            modified = set_actor_visibility(glyph_actor, visible) or modified
         return modified
 
     def set_volume_opacity(self, data_id: str, opacity: float) -> bool:
@@ -155,34 +201,12 @@ class VolumeSliceHandler(ObjectHandler):
             modified = self.preset_parser.apply_preset_to_volume(slice.GetProperty(), preset, is_inverted)
         return modified
 
-    def set_volume_normal_color(
-        self,
-        data_id: str,
-        show_arrows: bool,
-        sampling: int,
-        arrow_length: float,
-        arrow_width: float,
-        orientation: int,
-    ) -> bool:
-        logger.debug(f"set_volume_normal_color({data_id})")
-        modified = False
-        glyph_actors = self.get_glyph_actors(data_id)
-        if show_arrows and len(glyph_actors) == 0:
-            glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer, orientation)
-            self.register_data(data_id, glyph_actor)
-            glyph_actors = [glyph_actor]
-            modified = True
-        for glyph_actor in glyph_actors:
-            modified = set_actor_visibility(glyph_actor, show_arrows) or modified
-            modified = set_vector_field_sampling(glyph_actor, orientation, sampling) or modified
-            modified = set_vector_field_arrow_length(glyph_actor, arrow_length) or modified
-            modified = set_vector_field_arrow_thickness(glyph_actor, arrow_width) or modified
-        for image_slice in self.get_image_slices(data_id):
-            modified = set_actor_visibility(image_slice, not show_arrows) or modified
-        reslice_image_viewer = self.get_reslice_image_viewer(data_id)
-        if reslice_image_viewer is not None:
-            modified = set_actor_visibility(reslice_image_viewer, not show_arrows) or modified
-        return modified
+    def _init_glyph_actors(self, data_id: str) -> None:
+        volume = self.get_data(data_id)
+        if volume is None:
+            return
+        glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer, self.orientation)
+        self.register_data(data_id, glyph_actor)
 
     def get_reslice_image_viewer(self, data_id=None) -> vtkResliceImageViewer | None:
         """
@@ -211,19 +235,14 @@ class VolumeSliceHandler(ObjectHandler):
         return modified
 
 
-class VolumeThreeDHandler(ObjectHandler):
+class VolumeThreeDHandler(VolumeHandler):
     def __init__(self, preset_parser: VolumePresetParser) -> None:
-        super().__init__()
-        self.preset_parser = preset_parser
+        super().__init__(preset_parser)
 
     def apply_volume_display_properties(self, data_id: str, display_property: VolumeDisplay) -> None:
-        if display_property.threed_color is not None:
-            self.set_volume_preset(
-                data_id,
-                display_property.threed_color.name,
-                display_property.threed_color.vr_shift,
-            )
-        elif display_property.normal_color is not None:
+        if display_property.normal_color is not None:
+            self._set_volume_visibility(data_id, False)
+            self._init_glyph_actors(data_id)
             self.set_volume_normal_color(
                 data_id,
                 display_property.normal_color.show_arrows,
@@ -231,15 +250,21 @@ class VolumeThreeDHandler(ObjectHandler):
                 display_property.normal_color.arrow_length,
                 display_property.normal_color.arrow_width,
             )
+        else:
+            self.set_volume_preset(
+                data_id,
+                display_property.threed_color.name,
+                display_property.threed_color.vr_shift,
+            )
 
     def add_volume(self, data_id: str, image_data: vtkImageData) -> None:
         volume = render_volume_in_3D(image_data, self.renderer)
         self.register_data(data_id, volume)
 
-    def set_volume_visibility(self, data_id: str, visible: bool) -> bool:
+    def _set_volume_visibility(self, data_id: str, visible: bool) -> bool:
         logger.debug(f"set_volume_visibility({data_id}): {visible}")
         volume = self.get_data(data_id)
-        if volume is None:
+        if volume is None or len(self.get_glyph_actors(data_id)) > 0:
             return False
         return set_volume_visibility(volume, visible)
 
@@ -252,31 +277,3 @@ class VolumeThreeDHandler(ObjectHandler):
         if preset is None:
             return False
         return self.preset_parser.apply_preset(volume.GetProperty(), preset, range)
-
-    def set_volume_normal_color(
-        self,
-        data_id: str,
-        show_arrows: bool,
-        sampling: int,
-        arrow_length: float,
-        arrow_width: float,
-    ) -> bool:
-        volume = self.get_data(data_id)
-        if volume is None:
-            return False
-        logger.debug(f"set_volume_normal_color({data_id})")
-        modified = False
-        glyph_actors = self.get_glyph_actors(data_id)
-        if show_arrows and len(glyph_actors) == 0:
-            glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer)
-            self.register_data(data_id, glyph_actor)
-            glyph_actors = [glyph_actor]
-            modified = True
-        # FIXME: add a convenient function to set visibility of any actor
-        for glyph_actor in glyph_actors:
-            modified = set_actor_visibility(glyph_actor, show_arrows) or modified
-            modified = set_vector_field_sampling(glyph_actor, None, sampling) or modified
-            modified = set_vector_field_arrow_length(glyph_actor, arrow_length) or modified
-            modified = set_vector_field_arrow_thickness(glyph_actor, arrow_width) or modified
-
-        return modified

--- a/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
@@ -41,7 +41,7 @@ def get_orientation_from_view_type(view_type: ViewType) -> SliceOrientation | No
     return SliceOrientation.__members__.get(view_type.name)
 
 
-class SliceViewLogic(ViewLogic):
+class SliceViewLogic(ViewLogic[VolumeSliceHandler]):
     """Display volume as a 2D slice along a given axis/orientation"""
 
     _debounced_flush_initialized = False
@@ -64,7 +64,7 @@ class SliceViewLogic(ViewLogic):
             }
         )
 
-        self.volume_handler = VolumeSliceHandler(self.color_preset_parser)
+        self.volume_handler = VolumeSliceHandler(self.color_preset_parser, self.orientation.value)
 
     @property
     def position(self) -> tuple[float]:
@@ -103,19 +103,17 @@ class SliceViewLogic(ViewLogic):
     ):
         is_primary = False
         if subtype == SceneObjectSubtype.LABELMAP and layer == VolumeLayer.SECONDARY:
-            self.volume_handler.add_labelmap(data_id, image_data, self.orientation.value)
+            self.volume_handler.add_labelmap(data_id, image_data)
         elif layer == VolumeLayer.PRIMARY:
             is_primary = True
-            self.volume_handler.add_primary_volume(data_id, image_data, self.orientation.value)
+            self.volume_handler.add_primary_volume(data_id, image_data)
             self._set_reslice_interaction()
         elif layer == VolumeLayer.SECONDARY:
-            self.volume_handler.add_secondary_volume(data_id, image_data, self.orientation.value)
+            self.volume_handler.add_secondary_volume(data_id, image_data)
         else:
             raise ValueError("Volume layer cannot be undefined.")
 
-        self.volume_handler.apply_volume_display_properties(
-            data_id, display_properties, self.orientation.value, is_primary
-        )
+        self.volume_handler.apply_volume_display_properties(data_id, display_properties, is_primary)
 
     def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: MeshDisplay) -> None:
         self.mesh_handler.add_mesh_in_slice(data_id, poly_data, self.orientation.value)

--- a/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
@@ -16,7 +16,7 @@ from .view_logic import ViewLogic
 logger = logging.getLogger(__name__)
 
 
-class ThreeDViewLogic(ViewLogic):
+class ThreeDViewLogic(ViewLogic[VolumeThreeDHandler]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.volume_handler = VolumeThreeDHandler(self.volume_preset_parser)
@@ -29,14 +29,10 @@ class ThreeDViewLogic(ViewLogic):
         layer: VolumeLayer,
         subtype: SceneObjectSubtype,
     ) -> None:
-        if subtype in [SceneObjectSubtype.LABELMAP, SceneObjectSubtype.SCALAR] and layer == VolumeLayer.SECONDARY:
+        if subtype == SceneObjectSubtype.LABELMAP and layer == VolumeLayer.SECONDARY:
             return
-
         self.volume_handler.add_volume(data_id, image_data)
         self.volume_handler.apply_volume_display_properties(data_id, display_properties)
-
-        if subtype == SceneObjectSubtype.VECTOR and layer == VolumeLayer.SECONDARY:
-            self.volume_handler.set_volume_visibility(data_id, False)
 
     def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: MeshDisplay) -> None:
         self.mesh_handler.add_mesh_in_3D(data_id, poly_data)

--- a/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
@@ -1,6 +1,6 @@
 import logging
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 from trame_server.core import Server
 from trame_server.utils.typed_state import TypedState
@@ -17,17 +17,17 @@ from ....utils import (
 from ...base_logic import BaseLogic
 from ...scene.objects.volume_object_logic import VolumeDisplay
 from ..handlers.mesh_handler import MeshHandler
-from ..handlers.volume_handler import (
-    VolumeSliceHandler,
-    VolumeThreeDHandler,
-)
+from ..handlers.volume_handler import VolumeHandler
 from ..place_roi_logic import PlaceROILogic
 
 logger = logging.getLogger(__name__)
 
+T = TypeVar("T", bound=VolumeHandler)
 
-class ViewLogic(BaseLogic[ViewState]):
+
+class ViewLogic(BaseLogic[ViewState], Generic[T]):
     window_level_changed = Signal(str)
+    volume_handler: T
 
     def __init__(
         self,
@@ -42,7 +42,6 @@ class ViewLogic(BaseLogic[ViewState]):
         self.color_preset_parser = color_preset_parser
 
         self.mesh_handler = MeshHandler(color_preset_parser)
-        self.volume_handler: VolumeSliceHandler | VolumeThreeDHandler | None = None
 
         self._views_state = TypedState(self.state, ViewsState)
 
@@ -76,11 +75,7 @@ class ViewLogic(BaseLogic[ViewState]):
         pass
 
     def remove_volume(self, data_id: str, only_data: Any | None = None) -> None:
-        if self.volume_handler is None:
-            return
         self.volume_handler.unregister_data(data_id, only_data)
 
     def remove_mesh(self, data_id: str, only_data: Any | None = None) -> None:
-        if self.mesh_handler is None:
-            return
         self.mesh_handler.unregister_data(data_id, only_data)

--- a/girdermedviewer/app/widgets/logic/vtk/views_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views_logic.py
@@ -5,6 +5,8 @@ from trame_server.utils.typed_state import TypedState
 from undo_stack import Signal
 from vtk import vtkImageData, vtkPolyData
 
+from girdermedviewer.app.widgets.logic.vtk.handlers.volume_handler import VolumeHandler
+
 from ...logic.base_logic import BaseLogic
 from ...ui import ToolState, ToolType, ToolUI, ViewsState, ViewsUI, ViewType
 from ...utils import (
@@ -26,7 +28,7 @@ class ViewsLogic(BaseLogic[ViewsState]):
 
     def __init__(self, server: Server) -> None:
         super().__init__(server, ViewsState)
-        self.view_logics: dict[ViewType, ViewLogic] = {}
+        self.view_logics: dict[ViewType, ViewLogic[VolumeHandler]] = {}
         self.ctrl.reset = self.reset
 
         self.volume_preset_parser = get_volume_preset_parser()
@@ -50,7 +52,7 @@ class ViewsLogic(BaseLogic[ViewsState]):
         self.segmentation_logic.update_requested.connect(self.update_slice_views)
 
     @property
-    def views(self) -> list[ViewLogic]:
+    def views(self) -> list[ViewLogic[VolumeHandler]]:
         return list(self.view_logics.values())
 
     @property
@@ -72,7 +74,7 @@ class ViewsLogic(BaseLogic[ViewsState]):
 
         self.update_views()
 
-    def _is_view_shown(self, view_logic: ViewLogic) -> bool:
+    def _is_view_shown(self, view_logic: ViewLogic[VolumeHandler]) -> bool:
         return self.data.fullscreen is None or self.data.fullscreen == view_logic.type
 
     def update_views(self) -> None:

--- a/girdermedviewer/app/widgets/ui/scene/filters/filter_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/filters/filter_ui.py
@@ -38,8 +38,8 @@ class FilterToolbarUI(html.Div):
 
 
 class FilterUI(html.Div):
-    def __init__(self, obj: str, disabled: str, **kwargs) -> None:
-        super().__init__(classes=(f"{disabled} ? 'disabled' : ''",), **kwargs)
+    def __init__(self, obj: str, **kwargs) -> None:
+        super().__init__(**kwargs)
         self._filter_type = f"{obj}.filter_type"
 
         with self, Provider(name="filter_prop", instance=(f"{obj}.filter_prop_id",)):

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_color_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_color_ui.py
@@ -238,4 +238,4 @@ class VolumeDisplayNormalColorUI(html.Div):
                     precision=2,
                 )
 
-            VolumeWindowLevelUI(self.display, disabled=f"{self.display}.normal_color.show_arrows")
+            VolumeWindowLevelUI(self.display, is_disabled=f"{self.display}.normal_color.show_arrows")

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
@@ -1,6 +1,5 @@
 from trame.widgets import html
 from trame.widgets import vuetify3 as v3
-from trame_dataclass.v2 import Provider
 
 from ....utils import SceneObjectSubtype, SceneObjectType
 from .object_display_color_ui import (
@@ -79,13 +78,13 @@ class MeshDisplayUI(html.Div):
 
 
 class SceneObjectDisplayUI(html.Div):
-    def __init__(self, obj: str, disabled: str, is_primary: str, color_presets: str, volume_presets: str, **kwargs):
-        super().__init__(classes=(f"{disabled} ? 'disabled' : ''",), **kwargs)
+    def __init__(self, obj: str, obj_display: str, is_primary: str, color_presets: str, volume_presets: str, **kwargs):
+        super().__init__(**kwargs)
         self.obj = obj
 
-        with self, Provider(name="display", instance=(f"{self.obj}.display",)):
+        with self:
             VolumeDisplayUI(
-                obj_display="display",
+                obj_display=obj_display,
                 obj_subtype=f"{self.obj}.object_subtype",
                 is_primary=is_primary,
                 twod_presets=color_presets,
@@ -93,7 +92,7 @@ class SceneObjectDisplayUI(html.Div):
                 v_if=(self._is_object_type(SceneObjectType.VOLUME),),
             )
             MeshDisplayUI(
-                obj_display="display",
+                obj_display=obj_display,
                 scalar_presets=color_presets,
                 v_if=(self._is_object_type(SceneObjectType.MESH),),
             )

--- a/girdermedviewer/app/widgets/ui/scene/scene_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/scene_ui.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from trame.widgets import html
 from trame.widgets import vuetify3 as v3
-from trame_dataclass.v2 import get_instance
+from trame_dataclass.v2 import Provider, get_instance
 from trame_server.utils.typed_state import TypedState
 from undo_stack import Signal
 
@@ -54,11 +54,8 @@ class SceneObjectUI(v3.VExpansionPanel):
     def _is_active_primary_volume(self) -> str:
         return f"({self._typed_state.name.active_primary_volume_id} === {self._obj}._id)"
 
-    def _is_disabled(self) -> str:
-        return f"!{self._obj}.is_visible"
-
     def _build_ui(self):
-        with self:
+        with self, Provider(name="display", instance=(f"{self._obj}.display",)):
             with v3.VExpansionPanelTitle(v_if=(f"{self._obj}.gui.loading",), classes="item-card-title"):
                 Text("{{ " + self._obj + ".name }}", classes="text-header font-weight-medium")
                 with v3.Template(v_slot_actions="{ expanded }"):
@@ -81,10 +78,11 @@ class SceneObjectUI(v3.VExpansionPanel):
                 )
                 with v3.Template(v_slot_actions="{ expanded }"):
                     Button(
+                        v_if=("display_available",),
                         click_stop=(self.visibility_clicked, f"[{self._obj}._id]"),
-                        icon=(f"{self._obj}.is_visible ? 'mdi-eye-outline' : 'mdi-eye-off-outline'",),
+                        icon=("display.is_visible ? 'mdi-eye-outline' : 'mdi-eye-off-outline'",),
                         size="small",
-                        tooltip=(f"{self._obj}.is_visible ? 'Hide' : 'Show'",),
+                        tooltip=("display.is_visible ? 'Hide' : 'Show'",),
                     )
 
             with v3.VExpansionPanelText(v_if=(f"!{self._obj}.gui.loading",)), v3.VCard():
@@ -147,21 +145,22 @@ class SceneObjectUI(v3.VExpansionPanel):
                     v3.VWindow(v_model=(f"{self._obj}.gui.current_window"), style="overflow: unset;"),
                 ):
                     with (
-                        v3.VWindowItem(value="filter", v_if=(f"{self._obj}.filter_type",)),
+                        v3.VWindowItem(value="filter", v_if=(f"display_available && {self._obj}.filter_type",)),
                     ):
                         self.filter_ui = FilterUI(
+                            classes=("display.is_visible ? '' : 'disabled'",),
                             obj=self._obj,
-                            disabled=self._is_disabled(),
                         )
 
                     with (
-                        v3.VWindowItem(value="display", v_if=(f"{self._obj}.display",)),
+                        v3.VWindowItem(value="display", v_if=("display_available",)),
                     ):
                         SceneObjectDisplayUI(
-                            obj=self._obj,
-                            disabled=self._is_disabled(),
-                            is_primary=self._is_primary_volume(),
+                            classes=("display.is_visible ? '' : 'disabled'",),
                             color_presets=f"{self._scene}.color_presets",
+                            is_primary=self._is_primary_volume(),
+                            obj=self._obj,
+                            obj_display="display",
                             volume_presets=f"{self._scene}.volume_presets",
                         )
 

--- a/girdermedviewer/app/widgets/utils/vtk/vtk_utils.py
+++ b/girdermedviewer/app/widgets/utils/vtk/vtk_utils.py
@@ -453,7 +453,7 @@ def set_slice_visibility(image_slice: vtkImageSlice, visible: bool) -> bool:
     return True
 
 
-def render_volume_as_vector_field(image_data: vtkImageData, renderer: vtkRenderer, axis: int | None):
+def render_volume_as_vector_field(image_data: vtkImageData, renderer: vtkRenderer, axis: int | None = None):
     """
     Render the volume as a vector field in the slice defined by axis.
     :param axis: the normal axis of the slice, if None, the vector field
@@ -508,7 +508,7 @@ def get_vector_field_shrinker(glyph_actor: vtkActor | None) -> vtkImageReslice |
 
 
 # FIXME: to merge in a unique set_vector_field_properties function
-def set_vector_field_sampling(glyph_actor: vtkActor | None, axis: int | None, sampling: int) -> bool:
+def set_vector_field_sampling(glyph_actor: vtkActor | None, sampling: int, axis: int | None = None) -> bool:
     if glyph_actor is None:
         return False
     shrinker = get_vector_field_shrinker(glyph_actor)

--- a/girdermedviewer/app/widgets/utils/vtk/vtk_utils.py
+++ b/girdermedviewer/app/widgets/utils/vtk/vtk_utils.py
@@ -453,7 +453,7 @@ def set_slice_visibility(image_slice: vtkImageSlice, visible: bool) -> bool:
     return True
 
 
-def render_volume_as_vector_field(image_data: vtkImageData, renderer: vtkRenderer, axis: int | None = None):
+def render_volume_as_vector_field(image_data: vtkImageData, renderer: vtkRenderer, axis: int | None):
     """
     Render the volume as a vector field in the slice defined by axis.
     :param axis: the normal axis of the slice, if None, the vector field
@@ -512,7 +512,9 @@ def set_vector_field_sampling(glyph_actor: vtkActor | None, axis: int | None, sa
     if glyph_actor is None:
         return False
     shrinker = get_vector_field_shrinker(glyph_actor)
-    new_sampling = (sampling, sampling, sampling) if axis is None else [sampling if i != axis else 100 for i in range(3)]
+    new_sampling = (
+        (sampling, sampling, sampling) if axis is None else [sampling if i != axis else 100 for i in range(3)]
+    )
     input_image = shrinker.GetInput()
 
     spacing = input_image.GetSpacing()


### PR DESCRIPTION
Main quest:
- Fixes conflict between volume visibility and arrows visibility for RGB (vector) volumes
- Hide volume rendering of RGB volumes except if it show arrows
- Always set the twod color for primary volumes (vector or scalar)

Side quests:
- **Create abstract class VolumeHandler class**: for type hinting purposes
- **Fix Type hinting of volume_handler attribute in ViewLogic**
- **Rolled back: render all volumes in 3D**: mentioned here #53 
