### PR TITLE
feat(tool): create tool logic that handles all tools and toolbar status

### DIFF
--- a/girdermedviewer/app/widgets/logic/app_logic.py
+++ b/girdermedviewer/app/widgets/logic/app_logic.py
@@ -9,6 +9,7 @@ from ..utils import AppConfig, GirderConfig
 from .base_logic import BaseLogic
 from .girder import GirderLogic
 from .scene import SceneLogic
+from .vtk.tool_logic import ToolLogic
 from .vtk.views_logic import ViewsLogic
 
 logger = logging.getLogger(__name__)
@@ -21,13 +22,15 @@ class AppLogic(BaseLogic[AppState]):
 
         self._views_logic = ViewsLogic(self.server)
         self._scene_logic = SceneLogic(self.server, self._views_logic)
+        self._tool_logic = ToolLogic(self.server, self._views_logic, self._scene_logic)
         self._girder_logic = GirderLogic(self.server, self._scene_logic, self.app_config)
         self.provider = self._girder_logic.connection_logic.provider
 
     def set_ui(self, ui: AppUI) -> None:
-        self._girder_logic.set_ui(ui)
+        self._views_logic.set_ui(ui.views_ui)
+        self._tool_logic.set_ui(ui.tool_ui)
         self._scene_logic.set_ui(ui.scene_ui)
-        self._views_logic.set_ui(ui.views_ui, ui.tool_ui)
+        self._girder_logic.set_ui(ui)
 
     def _load_app_config(self, config_file_path: Path | None = None) -> None:
         """

--- a/girdermedviewer/app/widgets/logic/scene/handlers/object_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/object_handler.py
@@ -1,5 +1,5 @@
 import logging
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from pathlib import Path
 
 from trame_server.core import Server
@@ -12,7 +12,7 @@ from ..objects.scene_object_logic import SceneObjectLogic
 logger = logging.getLogger(__name__)
 
 
-class ObjectHandler(BaseLogic[SceneState]):
+class ObjectHandler(BaseLogic[SceneState], ABC):
     def __init__(self, server: Server, views_logic: ViewsLogic):
         super().__init__(server, SceneState)
         self.object_logics: dict[str, SceneObjectLogic] = {}

--- a/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
@@ -3,6 +3,8 @@ from collections.abc import Callable
 
 from trame_dataclass.v2 import get_instance
 from trame_server.core import Server
+from undo_stack import Signal
+from vtk import vtkImageData
 
 from ....utils import (
     SceneObjectSubtype,
@@ -68,6 +70,9 @@ class SegmentationDisplayHandler:
 
 
 class SegmentationHandler(ObjectHandler):
+    segment_selected = Signal(vtkImageData | None, int)
+    segment_cleared = Signal(vtkImageData, int)
+
     def __init__(self, server: Server, views_logic: ViewsLogic):
         super().__init__(server, views_logic)
         self._display_handler = SegmentationDisplayHandler(views_logic)
@@ -121,11 +126,11 @@ class SegmentationHandler(ObjectHandler):
 
             self.data.active_segment_id = segment_id
             self.data.active_labelmap_id = seg_filter_logic._id
-            self.views_logic.segmentation_logic.set_active_segment(seg_filter_logic.object_data, segment_value)
+            self.segment_selected(seg_filter_logic.object_data, segment_value)
         else:
             self.data.active_segment_id = None
             self.data.active_labelmap_id = None
-            self.views_logic.segmentation_logic.set_active_segment(None, 0)
+            self.segment_selected(None, 0)
 
     def add_segment_to_labelmap(self, seg_filter_logic: SegmentationFilterLogic) -> None:
         new_segment = seg_filter_logic.create_segment()
@@ -138,7 +143,7 @@ class SegmentationHandler(ObjectHandler):
     def delete_segment_from_labelmap(self, seg_filter_logic: SegmentationFilterLogic, deleted_segment_id: str) -> None:
         deleted_segment = SegmentationHandler._get_segment_from_id(deleted_segment_id)
         deleted_segment.clear_watchers()
-        self.views_logic.segmentation_logic.clear_segment(seg_filter_logic.object_data, deleted_segment.value)
+        self.segment_cleared(seg_filter_logic.object_data, deleted_segment.value)
         self.views_logic.update_slice_views()
         seg_filter_logic.delete_segment(deleted_segment_id)
 

--- a/girdermedviewer/app/widgets/logic/scene/objects/scene_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/scene_object_logic.py
@@ -1,5 +1,5 @@
 import logging
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 
 from trame_dataclass.v2 import (
     ClientOnly,
@@ -77,7 +77,7 @@ class SceneObject(StateDataModel):
     filter_prop_id = Sync(str)
 
 
-class SceneObjectLogic(BaseLogic[None]):
+class SceneObjectLogic(BaseLogic[None], ABC):
     """
     Defines properties of object added to the scene:
         - display, info, metadata

--- a/girdermedviewer/app/widgets/logic/scene/scene_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/scene_logic.py
@@ -3,6 +3,7 @@ import logging
 from trame_dataclass.v2 import StateDataModel, Sync, get_instance
 from trame_server import Server
 from undo_stack import Signal
+from vtk import vtkImageData
 
 from ...ui import SceneState, SceneUI
 from ...utils import (
@@ -40,6 +41,8 @@ class SceneLogic(BaseLogic[SceneState]):
     object_added = Signal(str)
     object_removed = Signal(str, str)
     object_load_canceled = Signal(str)
+    segment_selected = Signal(vtkImageData, int)
+    segment_cleared = Signal(vtkImageData, int)
 
     def __init__(self, server: Server, views_logic: ViewsLogic) -> None:
         super().__init__(server, SceneState)
@@ -52,6 +55,8 @@ class SceneLogic(BaseLogic[SceneState]):
         self.mesh_handler = MeshHandler(self.server, views_logic)
         self.volume_handler = VolumeHandler(self.server, views_logic)
         self.segmentation_handler = SegmentationHandler(self.server, views_logic)
+        self.segmentation_handler.segment_selected.connect(self.segment_selected)
+        self.segmentation_handler.segment_cleared.connect(self.segment_cleared)
 
     def _get_presets_from_preset_parser(self, preset_parser: PresetParser) -> list[Preset]:
         return [

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
@@ -93,3 +93,6 @@ class MeshHandler(ObjectHandler):
                 self.preset_parser.apply_preset_to_mesh(actor, array_obj, preset, preset_range, is_inverted) or modified
             )
         return modified
+
+    def has_mesh(self) -> bool:
+        return len(list(self.object_data)) > 0

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
@@ -21,6 +21,7 @@ class ObjectHandler:
         self.object_data = defaultdict(list)
         self.object_display = defaultdict(list)
         self.renderer: vtkRenderer | None = None
+        self.roi_id: str | None = None
 
     def set_renderer(self, renderer: vtkRenderer) -> None:
         self.renderer = renderer

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -1,5 +1,5 @@
 import logging
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any
 
 from vtk import (
@@ -38,7 +38,7 @@ from .object_handler import ObjectHandler
 logger = logging.getLogger(__name__)
 
 
-class VolumeHandler(ObjectHandler):
+class VolumeHandler(ObjectHandler, ABC):
     def __init__(self, preset_parser: PresetParser):
         super().__init__()
         self.preset_parser = preset_parser

--- a/girdermedviewer/app/widgets/logic/vtk/tool_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/tool_logic.py
@@ -1,0 +1,71 @@
+import logging
+
+from trame_server import Server
+from vtk import vtkImageData
+
+from ...ui import ToolState, ToolType, ToolUI
+from ..base_logic import BaseLogic
+from ..scene.scene_logic import SceneLogic
+from .tools.place_roi_logic import PlaceROILogic
+from .tools.segmentation_effect_logic import SegmentationEffectLogic
+from .views_logic import ViewsLogic
+
+logger = logging.getLogger(__name__)
+
+
+class ToolLogic(BaseLogic[ToolState]):
+    def __init__(self, server: Server, views_logic: ViewsLogic, scene_logic: SceneLogic) -> None:
+        super().__init__(server, ToolState)
+        self._views_logic = views_logic
+        self._views_logic.object_added.connect(self._on_object_added)
+        self._views_logic.primary_volume_added.connect(self._on_primary_volume_added)
+
+        self._scene_logic = scene_logic
+        self._scene_logic.segment_selected.connect(self._on_segment_selected)
+
+        # ROI tool
+        self._roi_logic = PlaceROILogic(self.server, self._views_logic)
+
+        # Segmentation tool
+        self._segmentation_logic = SegmentationEffectLogic(self.server, self._views_logic)
+        self._scene_logic.segment_selected.connect(self._segmentation_logic.set_active_segment)
+        self._scene_logic.segment_cleared.connect(self._segmentation_logic.clear_segment)
+
+        # Watchers
+        self.bind_changes({self.name.active_tool: self._on_tool_change})
+        self._views_logic.bind_changes({self._views_logic.name.is_viewer_disabled: self._on_viewer_status_changed})
+
+    def _reset_tool_state(self):
+        self._typed_state.set_dataclass(ToolState())
+
+    def _on_object_added(self) -> None:
+        self.data.is_toolbar_disabled = False
+
+    def _on_primary_volume_added(self, image_data: vtkImageData) -> None:
+        self.data.is_oblique_tool_disabled = False
+        self.data.is_point_tool_disabled = False
+        self.data.is_roi_tool_disabled = False
+        self._roi_logic.set_default_bounds(image_data.GetBounds())
+        self._segmentation_logic.set_paint_effects(self._views_logic.slice_views)
+
+    def _on_segment_selected(self, _image_data: vtkImageData | None, value: int):
+        if value == 0:
+            self.data.is_segmentation_tool_disabled = True
+            self.data.active_tool = ToolType.UNDEFINED
+        else:
+            self.data.is_segmentation_tool_disabled = False
+            self.data.active_tool = ToolType.SEGMENTATION_EFFECT
+
+    def _on_viewer_status_changed(self, is_viewer_disabled: bool) -> None:
+        if is_viewer_disabled:
+            self._reset_tool_state()
+
+    def _on_tool_change(self, active_tool: ToolType) -> None:
+        self._roi_logic.set_enabled(active_tool == ToolType.PLACE_ROI)
+        self._segmentation_logic.set_enabled(active_tool == ToolType.SEGMENTATION_EFFECT)
+        self._views_logic.update_views()
+
+    def set_ui(self, ui: ToolUI) -> None:
+        ui.reset_clicked.connect(self._views_logic.reset)
+
+        self._roi_logic.set_ui(ui.place_roi_ui)

--- a/girdermedviewer/app/widgets/logic/vtk/tools/base_tool_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/tools/base_tool_logic.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+
+from trame_server import Server
+
+from ...base_logic import BaseLogic, T
+from ..views_logic import ViewsLogic
+
+
+class BaseToolLogic(BaseLogic[T], ABC):
+    def __init__(self, server: Server, views_logic: ViewsLogic, state_type: type[T] | None, state_namespace: str = ""):
+        super().__init__(server, state_type, state_namespace)
+        self._views_logic = views_logic
+
+    @abstractmethod
+    def set_enabled(self, enabled: bool) -> None:
+        pass

--- a/girdermedviewer/app/widgets/logic/vtk/tools/place_roi_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/tools/place_roi_logic.py
@@ -1,32 +1,31 @@
 import logging
 
 from trame_server import Server
-from undo_stack import Signal
 from vtk import vtkBoxRepresentation, vtkBoxWidget2, vtkPolyData
+from vtkmodules.vtkRenderingCore import vtkActor
 
-from ...ui import PlaceROIState, PlaceROIUI, PointState
-from ..base_logic import BaseLogic
+from ....ui import PlaceROIState, PlaceROIUI, PointState
+from ....utils import render_mesh_in_slice, set_mesh_visibility
+from ..views_logic import ViewsLogic
+from .base_tool_logic import BaseToolLogic
 
 logger = logging.getLogger(__name__)
 
 
-class PlaceROILogic(BaseLogic[PlaceROIState]):
-    roi_updated = Signal()
-
-    def __init__(self, server: Server) -> None:
-        super().__init__(server, PlaceROIState)
+class PlaceROILogic(BaseToolLogic[PlaceROIState]):
+    def __init__(self, server: Server, views_logic: ViewsLogic) -> None:
+        super().__init__(server, views_logic, PlaceROIState)
         self._min_bounds_state = self._typed_state.get_sub_state(self.name.min_roi_bounds)
         self._max_bounds_state = self._typed_state.get_sub_state(self.name.max_roi_bounds)
 
-        self._id = "ROI"
+        self.box = vtkBoxRepresentation()
+        self.poly_data = vtkPolyData()
         self.box_widget = vtkBoxWidget2()
+        self.box_actors: list[vtkActor] = []
 
-        self.slice_rep = vtkPolyData()
-        self.threed_rep = vtkBoxRepresentation()
-
-        self.box_widget.SetRepresentation(self.threed_rep)
+        self.box_widget.SetRepresentation(self.box)
         self.box_widget.RotationEnabledOff()
-        self.threed_rep.SetPlaceFactor(1.0)
+        self.box.SetPlaceFactor(1.0)
 
         self._update_slice_rep()
 
@@ -61,12 +60,12 @@ class PlaceROILogic(BaseLogic[PlaceROIState]):
             self.box_widget.ProcessEventsOn()
 
     def _update_slice_rep(self) -> None:
-        self.threed_rep.GetPolyData(self.slice_rep)
+        self.box.GetPolyData(self.poly_data)
 
     def _update_from_widget(self, *_args) -> None:
         if self.data.is_roi_locked:
             return
-        new_bounds = self.threed_rep.GetBounds()
+        new_bounds = self.box.GetBounds()
         self._set_bounds(new_bounds)
         self.state.flush()
 
@@ -75,10 +74,10 @@ class PlaceROILogic(BaseLogic[PlaceROIState]):
             return
 
         roi_bounds = self._get_bounds()
-        if roi_bounds != self.threed_rep.GetBounds():
-            self.threed_rep.PlaceWidget(roi_bounds)
+        if roi_bounds != self.box.GetBounds():
+            self.box.PlaceWidget(roi_bounds)
         self._update_slice_rep()
-        self.roi_updated()
+        self._views_logic.update_views()
 
     def _reset(self) -> None:
         self._set_bounds(self.default_bounds)
@@ -105,11 +104,24 @@ class PlaceROILogic(BaseLogic[PlaceROIState]):
         self.name.is_roi_locked = False
         self._reset()
 
-    def enable_widget(self, enable: bool) -> None:
-        if enable:
+    def set_enabled(self, enabled: bool) -> None:
+        for actor in self.box_actors:
+            set_mesh_visibility(actor, enabled)
+        if enabled:
             self.box_widget.On()
         else:
             self.box_widget.Off()
 
     def set_ui(self, ui: PlaceROIUI) -> None:
         ui.reset_clicked.connect(self._reset)
+
+        for view_logic in self._views_logic.threed_views:
+            self.box_widget.SetInteractor(view_logic.renderer.GetRenderWindow().GetInteractor())
+            self.box_widget.SetCurrentRenderer(view_logic.renderer)
+
+        self.box_actors = []
+        for view_logic in self._views_logic.slice_views:
+            actor = render_mesh_in_slice(self.poly_data, view_logic.orientation.value, view_logic.renderer)
+            self.box_actors.append(actor)
+
+        self.set_enabled(False)

--- a/girdermedviewer/app/widgets/logic/vtk/tools/segmentation_effect_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/tools/segmentation_effect_logic.py
@@ -2,20 +2,20 @@ import logging
 
 from trame_dataclass.v2 import StateDataModel, Sync
 from trame_server import Server
-from undo_stack import Signal
 from vtk import vtkImageData
 
-from ...ui import SegmentationEffectState
-from ...utils import SegmentationEffectType
-from ...utils.vtk.segmentation import (
+from ....ui import SegmentationEffectState
+from ....utils import SegmentationEffectType
+from ....utils.vtk.segmentation import (
     BrushModel,
     BrushShape,
     LabelMapEditor,
     LabelMapOperation,
     SegmentPaintEffect2D,
 )
-from ..base_logic import BaseLogic
-from .views.slice_view_logic import SliceViewLogic
+from ..views.slice_view_logic import SliceViewLogic
+from ..views_logic import ViewsLogic
+from .base_tool_logic import BaseToolLogic
 
 logger = logging.getLogger(__name__)
 
@@ -25,16 +25,14 @@ class PaintEraseEffectProperties(StateDataModel):
     use_sphere_brush = Sync(bool, True)
 
 
-class SegmentationEffectLogic(BaseLogic[SegmentationEffectState]):
-    update_requested = Signal()
-
-    def __init__(self, server: Server) -> None:
-        super().__init__(server, SegmentationEffectState)
+class SegmentationEffectLogic(BaseToolLogic[SegmentationEffectState]):
+    def __init__(self, server: Server, views_logic: ViewsLogic) -> None:
+        super().__init__(server, views_logic, SegmentationEffectState)
         self.paint_erase_effect_prop = PaintEraseEffectProperties(self.server)
 
         self._segmentation_editor = LabelMapEditor()
         self._brush_model = BrushModel(BrushShape.Sphere)
-        self._paint_effects = []
+        self._paint_effects: list[SegmentPaintEffect2D] = []
 
         self.bind_changes({self.name.active_effect: self._update_active_effect})
         self.paint_erase_effect_prop.watch(("brush_size",), self._update_brush_size)
@@ -46,7 +44,7 @@ class SegmentationEffectLogic(BaseLogic[SegmentationEffectState]):
             for effect in self._paint_effects:
                 effect.disable_brush()
         elif not self._segmentation_editor.active_segment:
-            self.deactivate_effects()
+            self._deactivate_effects()
         else:
             self.data.active_effect_prop_id = self.paint_erase_effect_prop._id
 
@@ -67,6 +65,9 @@ class SegmentationEffectLogic(BaseLogic[SegmentationEffectState]):
     def _update_use_sphere_brush(self, use_sphere_brush: bool) -> None:
         self._brush_model.shape = BrushShape.Sphere if use_sphere_brush else BrushShape.Cylinder
 
+    def _deactivate_effects(self) -> None:
+        self.data.active_effect = SegmentationEffectType.UNDEFINED
+
     def set_paint_effects(self, slice_views: list[SliceViewLogic]) -> None:
         if not self._paint_effects:  # FIXME: needed to add this to not recreate SegmentPaintEffect2D
             for view in slice_views:
@@ -74,16 +75,17 @@ class SegmentationEffectLogic(BaseLogic[SegmentationEffectState]):
                     view.volume_handler.get_reslice_image_viewer(), self._segmentation_editor, self._brush_model
                 )
                 self._paint_effects.append(paint_effect)
-                paint_effect.update_requested.connect(self.update_requested)
+                paint_effect.update_requested.connect(self._views_logic.update_slice_views)
 
     def set_active_segment(self, object_data: vtkImageData | None, segment_value: int) -> None:
         if object_data is None:
-            self.deactivate_effects()
+            self._deactivate_effects()
         self._segmentation_editor.labelmap = object_data
         self._segmentation_editor.active_segment = segment_value
 
-    def clear_segment(self, object_data: vtkImageData, segment_value: int):
+    def clear_segment(self, object_data: vtkImageData, segment_value: int) -> None:
         self._segmentation_editor.clear_segment(object_data, segment_value)
 
-    def deactivate_effects(self):
-        self.data.active_effect = SegmentationEffectType.UNDEFINED
+    def set_enabled(self, enabled: bool) -> None:
+        if not enabled:
+            self._deactivate_effects()

--- a/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
@@ -1,7 +1,7 @@
 import logging
 from enum import Enum
 
-from vtk import vtkImageData, vtkPolyData, vtkRenderWindowInteractor
+from vtk import vtkImageData, vtkPolyData
 from vtkmodules.vtkInteractionImage import vtkResliceImageViewer
 from vtkmodules.vtkInteractionWidgets import vtkResliceCursorWidget
 
@@ -25,7 +25,6 @@ from ....utils import (
 from ...scene.objects.mesh_object_logic import MeshDisplay
 from ...scene.objects.volume_object_logic import VolumeDisplay
 from ..handlers.volume_handler import VolumeSliceHandler
-from ..place_roi_logic import PlaceROILogic
 from .view_logic import ViewLogic
 
 logger = logging.getLogger(__name__)
@@ -119,10 +118,6 @@ class SliceViewLogic(ViewLogic[VolumeSliceHandler]):
         self.mesh_handler.add_mesh_in_slice(data_id, poly_data, self.orientation.value)
         self.mesh_handler.apply_mesh_display_properties(data_id, display_properties)
 
-    def init_roi(self, roi: PlaceROILogic) -> None:
-        self.mesh_handler.add_mesh_in_slice(roi._id, roi.slice_rep, self.orientation.value)
-        self.mesh_handler.set_mesh_visibility(roi._id, False)
-
     def flush(self) -> None:
         if SliceViewLogic.DEBOUNCED_FLUSH:
             self.ctrl.debounced_flush()
@@ -180,9 +175,9 @@ class SliceViewLogic(ViewLogic[VolumeSliceHandler]):
         self.flush()
 
     def on_reslice_cursor_end_interaction(self, *_args) -> None:
-        self.state.flush()  # flush state.position
+        self.flush()  # flush state.position
 
-    @debounce(0.3)
+    @debounce(0.05)
     def _update_slider(self, *_args) -> None:
         range = self.get_slice_range()
         self.data.slider_state.min_value = range[0]

--- a/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
@@ -10,7 +10,6 @@ from ....utils import (
 from ...scene.objects.mesh_object_logic import MeshDisplay
 from ...scene.objects.volume_object_logic import VolumeDisplay
 from ..handlers.volume_handler import VolumeThreeDHandler
-from ..place_roi_logic import PlaceROILogic
 from .view_logic import ViewLogic
 
 logger = logging.getLogger(__name__)
@@ -37,10 +36,6 @@ class ThreeDViewLogic(ViewLogic[VolumeThreeDHandler]):
     def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: MeshDisplay) -> None:
         self.mesh_handler.add_mesh_in_3D(data_id, poly_data)
         self.mesh_handler.apply_mesh_display_properties(data_id, display_properties)
-
-    def init_roi(self, roi: PlaceROILogic) -> None:
-        roi.box_widget.SetInteractor(self.renderer.GetRenderWindow().GetInteractor())
-        roi.box_widget.SetCurrentRenderer(self.renderer)
 
     def reset(self) -> None:
         reset_3D(self.renderer)

--- a/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
@@ -1,5 +1,5 @@
 import logging
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
 from trame_server.core import Server
@@ -15,17 +15,17 @@ from ....utils import (
     VolumePresetParser,
 )
 from ...base_logic import BaseLogic
+from ...scene.objects.mesh_object_logic import MeshDisplay
 from ...scene.objects.volume_object_logic import VolumeDisplay
 from ..handlers.mesh_handler import MeshHandler
 from ..handlers.volume_handler import VolumeHandler
-from ..place_roi_logic import PlaceROILogic
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=VolumeHandler)
 
 
-class ViewLogic(BaseLogic[ViewState], Generic[T]):
+class ViewLogic(BaseLogic[ViewState], Generic[T], ABC):
     window_level_changed = Signal(str)
     volume_handler: T
 
@@ -67,11 +67,7 @@ class ViewLogic(BaseLogic[ViewState], Generic[T]):
         pass
 
     @abstractmethod
-    def add_mesh(self, data_id: str, data: vtkImageData) -> None:
-        pass
-
-    @abstractmethod
-    def init_roi(self, roi: PlaceROILogic) -> None:
+    def add_mesh(self, data_id: str, data: vtkImageData, display_properties: MeshDisplay) -> None:
         pass
 
     def remove_volume(self, data_id: str, only_data: Any | None = None) -> None:

--- a/girdermedviewer/app/widgets/logic/vtk/views_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views_logic.py
@@ -1,14 +1,13 @@
 from typing import Any
 
 from trame_server.core import Server
-from trame_server.utils.typed_state import TypedState
 from undo_stack import Signal
 from vtk import vtkImageData, vtkPolyData
 
 from girdermedviewer.app.widgets.logic.vtk.handlers.volume_handler import VolumeHandler
 
 from ...logic.base_logic import BaseLogic
-from ...ui import ToolState, ToolType, ToolUI, ViewsState, ViewsUI, ViewType
+from ...ui import ViewsState, ViewsUI, ViewType
 from ...utils import (
     SceneObjectSubtype,
     VolumeLayer,
@@ -16,8 +15,6 @@ from ...utils import (
     get_volume_preset_parser,
 )
 from ..scene.objects.volume_object_logic import VolumeDisplay
-from .place_roi_logic import PlaceROILogic
-from .segmentation_effect_logic import SegmentationEffectLogic
 from .views.slice_view_logic import SliceViewLogic
 from .views.threed_view_logic import ThreeDViewLogic
 from .views.view_logic import ViewLogic
@@ -25,17 +22,16 @@ from .views.view_logic import ViewLogic
 
 class ViewsLogic(BaseLogic[ViewsState]):
     window_level_changed = Signal()
+    object_added = Signal()
+    all_objects_removed = Signal()
+    primary_volume_added = Signal(vtkImageData)
 
     def __init__(self, server: Server) -> None:
         super().__init__(server, ViewsState)
         self.view_logics: dict[ViewType, ViewLogic[VolumeHandler]] = {}
-        self.ctrl.reset = self.reset
 
         self.volume_preset_parser = get_volume_preset_parser()
         self.color_preset_parser = get_color_preset_parser()
-
-        self._tool_state = TypedState(self.state, ToolState)
-        self._tool_state.bind_changes({self._tool_state.name.active_tool: self._on_tool_change})
 
         for view_type in ViewType:
             view_logic_type = ThreeDViewLogic if view_type == ViewType.THREED else SliceViewLogic
@@ -46,10 +42,6 @@ class ViewsLogic(BaseLogic[ViewsState]):
                 color_preset_parser=self.color_preset_parser,
             )
             self.view_logics[view_type].window_level_changed.connect(self.window_level_changed)
-
-        self.roi_logic = PlaceROILogic(self.server)
-        self.segmentation_logic = SegmentationEffectLogic(self.server)
-        self.segmentation_logic.update_requested.connect(self.update_slice_views)
 
     @property
     def views(self) -> list[ViewLogic[VolumeHandler]]:
@@ -63,14 +55,30 @@ class ViewsLogic(BaseLogic[ViewsState]):
     def threed_views(self) -> list[ThreeDViewLogic]:
         return [view for view in self.view_logics.values() if isinstance(view, ThreeDViewLogic)]
 
-    def _on_tool_change(self, active_tool: ToolType) -> None:
-        self.roi_logic.enable_widget(active_tool == ToolType.PLACE_ROI)
-        for view_logic in self.views:
-            if isinstance(view_logic, SliceViewLogic):
-                view_logic.mesh_handler.set_mesh_visibility(self.roi_logic._id, active_tool == ToolType.PLACE_ROI)
+    def _reset_view_state(self):
+        self._typed_state.set_dataclass(ViewsState())
 
-        if active_tool != ToolType.SEGMENTATION_EFFECT:
-            self.segmentation_logic.deactivate_effects()
+    def _on_object_added(self) -> None:
+        if self.data.is_viewer_disabled:
+            self.data.is_viewer_disabled = False
+            self.object_added()
+
+        self.update_views()
+
+    def _on_object_removed(self) -> None:
+        has_object = False
+
+        for view_logic in self.slice_views:
+            has_object = (
+                view_logic.volume_handler.has_primary_volume()
+                or view_logic.volume_handler.has_secondary_volume()
+                or view_logic.mesh_handler.has_mesh()
+                or has_object
+            )
+
+        if not has_object:
+            self._reset_view_state()
+            self.all_objects_removed()
 
         self.update_views()
 
@@ -87,18 +95,12 @@ class ViewsLogic(BaseLogic[ViewsState]):
             if self._is_view_shown(view):
                 view.update()
 
-    def set_ui(self, ui: ViewsUI, tool_ui: ToolUI):
-        self.roi_logic.roi_updated.connect(self.update_views)
-
-        # Connect logics to UI
+    def set_ui(self, ui: ViewsUI):
+        # Connect view logics to UI
         for view_type, view_ui in ui.view_uis.items():
             view_logic = self.view_logics.get(view_type)
             if view_logic is not None:
                 view_logic.set_ui(view_ui)
-        self.roi_logic.set_ui(tool_ui.place_roi_ui)
-
-        # Init ROI
-        self._init_roi()
 
     def reset(self) -> None:
         for view_logic in self.views:
@@ -108,12 +110,14 @@ class ViewsLogic(BaseLogic[ViewsState]):
     def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: VolumeDisplay) -> None:
         for view_logic in self.views:
             view_logic.add_mesh(data_id, poly_data, display_properties)
-        self.update_views()
+
+        self._on_object_added()
 
     def remove_mesh(self, data_id: str, only_data: Any = None) -> None:
         for view_logic in self.views:
             view_logic.remove_mesh(data_id, only_data)
-        self.update_views()
+
+        self._on_object_removed()
 
     def add_volume(
         self,
@@ -126,39 +130,15 @@ class ViewsLogic(BaseLogic[ViewsState]):
         for view_logic in self.views:
             view_logic.add_volume(data_id, image_data, display_properties, layer, subtype)
 
+        self._on_object_added()
+
         if layer == VolumeLayer.PRIMARY:
             self.data.are_obliques_visible = True
             self.data.are_sliders_visible = True
-            self.data.is_viewer_disabled = False
-            self.roi_logic.set_default_bounds(image_data.GetBounds())
-            self.segmentation_logic.set_paint_effects(self.slice_views)
-
-        if subtype == SceneObjectSubtype.LABELMAP:
-            self._tool_state.data.active_tool = ToolType.SEGMENTATION_EFFECT
-
-        self.update_views()
+            self.primary_volume_added(image_data)
 
     def remove_volume(self, data_id: str, only_data: Any = None) -> None:
-        has_primary_volume = False
-        has_secondary_volume = False
         for view_logic in self.views:
             view_logic.remove_volume(data_id, only_data)
 
-            if isinstance(view_logic, SliceViewLogic):
-                has_primary_volume = view_logic.volume_handler.has_primary_volume() or has_primary_volume
-                has_secondary_volume = view_logic.volume_handler.has_secondary_volume() or has_secondary_volume
-
-        if not has_primary_volume:
-            self.data.normals = None
-            self.data.are_obliques_visible = False
-            self.data.is_viewer_disabled = True
-            if not has_secondary_volume:
-                self.data.position.pos_x, self.data.position.pos_y, self.data.position.pos_z = None, None, None
-                self.data.are_sliders_visible = False
-                self._tool_state.data.active_tool = ToolType.UNDEFINED
-
-        self.update_views()
-
-    def _init_roi(self) -> None:
-        for view_logic in self.views:
-            view_logic.init_roi(self.roi_logic)
+        self._on_object_removed()

--- a/girdermedviewer/app/widgets/ui/vtk/tool_ui.py
+++ b/girdermedviewer/app/widgets/ui/vtk/tool_ui.py
@@ -5,6 +5,7 @@ from enum import Enum
 from trame.widgets import html
 from trame.widgets import vuetify3 as v3
 from trame_server.utils.typed_state import TypedState
+from undo_stack import Signal
 
 from ...utils import Button
 from .tools.place_point_ui import PlacePointUI
@@ -24,10 +25,17 @@ class ToolType(Enum):
 
 @dataclass
 class ToolState:
+    is_toolbar_disabled: bool = True
+    is_oblique_tool_disabled: bool = True
+    is_roi_tool_disabled: bool = True
+    is_point_tool_disabled: bool = True
+    is_segmentation_tool_disabled: bool = True
     active_tool: ToolType = ToolType.UNDEFINED
 
 
 class ToolUI(html.Div):
+    reset_clicked = Signal()
+
     def __init__(self, **kwargs):
         super().__init__(
             classes="tools-strip",
@@ -38,13 +46,15 @@ class ToolUI(html.Div):
 
         with self:
             Button(
-                click=self.ctrl.reset,
+                click=self.reset_clicked,
+                disabled=(self._is_toolbar_disabled,),
                 icon="mdi-camera-flip-outline",
                 tooltip="Reset views",
             )
             self._build_tool_button(
                 click=self._toggle_obliques_visibility,
                 is_colored=self._views_state.name.are_obliques_visible,
+                is_disabled=self._typed_state.name.is_oblique_tool_disabled,
                 icon="mdi-cube-scan",
                 tooltip=(f"{self._views_state.name.are_obliques_visible} ? 'Hide obliques' : 'Show obliques'",),
             )
@@ -52,6 +62,7 @@ class ToolUI(html.Div):
             self._build_tool_button(
                 click=lambda: self._activate_tool(ToolType.PLACE_POINT),
                 is_colored=self._is_tool_active(ToolType.PLACE_POINT),
+                is_disabled=self._typed_state.name.is_point_tool_disabled,
                 icon="mdi-target",
                 tooltip="Place point",
             )
@@ -59,6 +70,7 @@ class ToolUI(html.Div):
             self._build_tool_button(
                 click=lambda: self._activate_tool(ToolType.PLACE_ROI),
                 is_colored=self._is_tool_active(ToolType.PLACE_ROI),
+                is_disabled=self._typed_state.name.is_roi_tool_disabled,
                 icon="mdi-crop",
                 tooltip="Place ROI",
             )
@@ -66,9 +78,14 @@ class ToolUI(html.Div):
             self._build_tool_button(
                 click=lambda: self._activate_tool(ToolType.SEGMENTATION_EFFECT),
                 is_colored=self._is_tool_active(ToolType.SEGMENTATION_EFFECT),
+                is_disabled=self._typed_state.name.is_segmentation_tool_disabled,
                 icon="mdi-shape",
                 tooltip="Segmentation tool",
             )
+
+    @property
+    def _is_toolbar_disabled(self) -> str:
+        return self._typed_state.name.is_toolbar_disabled
 
     def _toggle_obliques_visibility(self):
         self._views_state.data.are_obliques_visible = not self._views_state.data.are_obliques_visible
@@ -82,12 +99,13 @@ class ToolUI(html.Div):
     def _is_tool_active(self, tool_type: ToolType) -> str:
         return f"({self._typed_state.name.active_tool} === {tool_type.value})"
 
-    def _build_tool_button(self, is_colored: str | None = None, **kwargs):
+    def _build_tool_button(self, is_colored: str | None = None, is_disabled: str | None = None, **kwargs):
+        is_disabled = (
+            f"({is_disabled} || {self._is_toolbar_disabled})" if is_disabled is not None else self._is_toolbar_disabled
+        )
         Button(
-            color=(f"{is_colored} && !{self._views_state.name.is_viewer_disabled} ? 'primary' : 'undefined'",)
-            if is_colored
-            else None,
-            disabled=(self._views_state.name.is_viewer_disabled,),
+            color=(f"{is_colored} && !{is_disabled} ? 'primary' : 'undefined'",) if is_colored else None,
+            disabled=(is_disabled,),
             **kwargs,
         )
 

--- a/girdermedviewer/app/widgets/ui/vtk/views_ui.py
+++ b/girdermedviewer/app/widgets/ui/vtk/views_ui.py
@@ -37,7 +37,6 @@ class ViewsState:
     is_viewer_disabled: bool = True
     are_sliders_visible: bool = False
     are_obliques_visible: bool = False
-    is_position_menu_visible: bool = False
     fullscreen: ViewType | None = None
 
 

--- a/girdermedviewer/app/widgets/utils/scene_utils.py
+++ b/girdermedviewer/app/widgets/utils/scene_utils.py
@@ -40,6 +40,7 @@ class SceneObjectSubtype(DataclassEnum):
     SCALAR = "scalar_volume"
     VECTOR = "vector_volume"
     LABELMAP = "labelmap_volume"
+    ROI = "roi_mesh"
     UNDEFINED = None
 
 

--- a/girdermedviewer/app/widgets/utils/vtk/preset_utils.py
+++ b/girdermedviewer/app/widgets/utils/vtk/preset_utils.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import xml.etree.ElementTree as ET
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -84,7 +84,7 @@ class Preset(StateDataModel):
     props = Sync(dict[str, str], {})
 
 
-class PresetParser:
+class PresetParser(ABC):
     def __init__(self, presets_file: Path, icons_folder: Path | None):
         self.presets = self.parse_slicer_presets(presets_file)
         self.icons_folder = icons_folder


### PR DESCRIPTION
Create tool logic to handle : obliques, roi and segmentation and future tools
ViewsLogic and ViewLogic are now agnostic of tools that are used.
The ROI tool is now really just a tool: a widget + a 2D representation (that happens to be a mesh). Later ROI objects couls be created from this tool.

-> enable to disable specific tool easily, like segmentation when no segment is selected

Issue identified on sliders: #58 