### PR TITLE
Rendering pipeline

### DIFF
--- a/girdermedviewer/app/core.py
+++ b/girdermedviewer/app/core.py
@@ -12,7 +12,7 @@ class MedViewerApp(TrameApp):
         super().__init__(server, **kwargs)
         self._layout = AppLayout(self.server)
         self._logic = AppLogic(self.server)
-        self._ui = AppUI(self._layout, self._logic.provider, self._logic.app_config)
+        self._ui = AppUI(self._layout, self._logic.provider, self._logic.app_config, self._logic.render_windows)
 
         logging.basicConfig(stream=sys.stdout)
         # Silence dependencies logs and keep only the application ones

--- a/girdermedviewer/app/widgets/logic/app_logic.py
+++ b/girdermedviewer/app/widgets/logic/app_logic.py
@@ -25,6 +25,7 @@ class AppLogic(BaseLogic[AppState]):
         self._tool_logic = ToolLogic(self.server, self._views_logic, self._scene_logic)
         self._girder_logic = GirderLogic(self.server, self._scene_logic, self.app_config)
         self.provider = self._girder_logic.connection_logic.provider
+        self.render_windows = self._views_logic.render_windows
 
     def set_ui(self, ui: AppUI) -> None:
         self._views_logic.set_ui(ui.views_ui)

--- a/girdermedviewer/app/widgets/logic/scene/filters/segmentation_filter_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/filters/segmentation_filter_logic.py
@@ -29,6 +29,7 @@ class SegmentationFilterLogic(BaseVolumeObjectLogic):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.scene_object.object_subtype = SceneObjectSubtype.LABELMAP
+        self.display.opacity = 0.5
         self.layer = VolumeLayer.SECONDARY
 
         self._next_segment_id = 1

--- a/girdermedviewer/app/widgets/logic/scene/filters/segmentation_filter_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/filters/segmentation_filter_logic.py
@@ -7,12 +7,16 @@ from ..objects.volume_object_logic import BaseVolumeObjectLogic, VolumeObjectLog
 MAX_SEGMENTS_PER_LABELMAP = 255
 
 
+class SegmentDisplay(StateDataModel):
+    color = Sync(str)
+    is_visible = Sync(bool, True)
+
+
 class SegmentProperties(StateDataModel):
     name = Sync(str)
-    color = Sync(str)
+    display = Sync(SegmentDisplay, has_dataclass=True)
     value = ServerOnly(int)
     is_color_dialog_visible = Sync(bool, False)
-    is_visible = Sync(bool, True)
 
 
 class SegmentationFilterProperties(StateDataModel):
@@ -29,7 +33,6 @@ class SegmentationFilterLogic(BaseVolumeObjectLogic):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.scene_object.object_subtype = SceneObjectSubtype.LABELMAP
-        self.display.opacity = 0.5
         self.layer = VolumeLayer.SECONDARY
 
         self._next_segment_id = 1
@@ -61,7 +64,10 @@ class SegmentationFilterLogic(BaseVolumeObjectLogic):
             raise ValueError(f"Labelmap cannot exceed {MAX_SEGMENTS_PER_LABELMAP} segments.")
 
         new_segment = SegmentProperties(
-            self.server, name=f"Segment_{self._next_segment_id}", value=self._next_segment_id, color=get_random_color()
+            self.server,
+            name=f"Segment_{self._next_segment_id}",
+            value=self._next_segment_id,
+            display=SegmentDisplay(self.server, color=get_random_color()),
         )
         self.scene_object_filter.segments = [*self.segments, new_segment]
         self.update_next_segment_id()

--- a/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/mesh_handler.py
@@ -17,9 +17,9 @@ class MeshDisplayHandler:
         self.views_logic = views_logic
 
     def update_visibility(self, mesh_logic: MeshObjectLogic) -> Callable:
-        def _update_visibility(visible: bool) -> None:
+        def _update_visibility(*_args) -> None:
             for view in self.views_logic.views:
-                modified = view.mesh_handler.set_mesh_visibility(mesh_logic._id, visible)
+                modified = view.mesh_handler.update_mesh_visibility(mesh_logic._id, mesh_logic.display)
                 if modified:
                     view.update()
 
@@ -27,11 +27,9 @@ class MeshDisplayHandler:
 
     def update_opacity(self, mesh_logic: MeshObjectLogic) -> Callable:
         @debounce(0.05)
-        def _update_opacity(opacity: float) -> None:
-            if opacity < 0 or not mesh_logic.is_visible:
-                return
+        def _update_opacity(*_args) -> None:
             for view in self.views_logic.views:
-                modified = view.mesh_handler.set_mesh_opacity(mesh_logic._id, opacity)
+                modified = view.mesh_handler.update_mesh_opacity(mesh_logic._id, mesh_logic.display)
                 if modified:
                     view.update()
 
@@ -39,42 +37,29 @@ class MeshDisplayHandler:
 
     def update_solid_coloring(self, mesh_logic: MeshObjectLogic) -> Callable:
         @debounce(0.05)
-        def _update_solid_coloring(color: str) -> None:
-            if not mesh_logic.is_visible:
-                return
+        def _update_solid_coloring(*_args) -> None:
             for view in self.views_logic.views:
-                modified = view.mesh_handler.set_mesh_solid_color(mesh_logic._id, color)
+                modified = view.mesh_handler.update_mesh_solid_color(mesh_logic._id, mesh_logic.display)
                 if modified:
                     view.update()
 
         return _update_solid_coloring
 
     def update_array_coloring(self, mesh_logic: MeshObjectLogic) -> Callable:
-        def _update_array_coloring(name: str, is_inverted: bool, scalar_range: list[float]) -> None:
-            if not mesh_logic.is_visible:
-                return
-            active_array = get_instance(mesh_logic.display.active_array_id)
+        def _update_array_coloring(*_args) -> None:
             for view in self.views_logic.views:
-                modified = view.mesh_handler.set_mesh_array_color(
-                    mesh_logic._id,
-                    active_array,
-                    name,
-                    is_inverted,
-                    scalar_range,
-                )
+                modified = view.mesh_handler.update_mesh_array_color(mesh_logic._id, mesh_logic.display)
                 if modified:
                     view.update()
 
         return _update_array_coloring
 
     def update_active_array(self, mesh_logic: MeshObjectLogic) -> Callable:
-        def _update_active_array(active_array_id: str) -> None:
-            if not mesh_logic.is_visible:
-                return
-            active_array = get_instance(active_array_id)
+        def _update_active_array(*_args) -> None:
+            active_array = get_instance(mesh_logic.display.active_array_id)
             assert isinstance(active_array, DataArray)
             if active_array.coloring_mode == MeshColoringMode.SOLID:
-                self.update_solid_coloring(mesh_logic)(mesh_logic.display.solid_color)
+                self.update_solid_coloring(mesh_logic)()
 
             elif active_array.coloring_mode == MeshColoringMode.ARRAY:
                 mesh_logic.display.array_color.array_range = active_array.array_min_max

--- a/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/segmentation_handler.py
@@ -26,9 +26,9 @@ class SegmentationDisplayHandler:
         self.views_logic = views_logic
 
     def update_visibility(self, seg_logic: SegmentationFilterLogic) -> Callable:
-        def _update_visibility(visible: bool):
+        def _update_visibility(*_args):
             for view in self.views_logic.views:
-                modified = view.volume_handler.set_volume_visibility(seg_logic._id, visible)
+                modified = view.volume_handler.update_volume_visibility(seg_logic._id, seg_logic.display)
                 if modified:
                     view.update()
 
@@ -36,37 +36,37 @@ class SegmentationDisplayHandler:
 
     def update_opacity(self, seg_logic: SegmentationFilterLogic) -> Callable:
         @debounce(0.05)
-        def _update_opacity(opacity: float) -> None:
-            if opacity < 0 or not seg_logic.is_visible:
-                return
+        def _update_opacity(*_args) -> None:
             for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_volume_opacity(seg_logic._id, opacity)
+                modified = view.volume_handler.update_volume_opacity(seg_logic._id, seg_logic.display)
                 if modified:
                     view.update()
 
         return _update_opacity
 
-    def update_segment_color(self, seg_logic: SegmentationFilterLogic, segment_id: int) -> Callable:
-        def _update_segment_color(color: str) -> None:
-            if not seg_logic.is_visible:
-                return
+    def update_segment_color(
+        self, seg_logic: SegmentationFilterLogic, segment_properties: SegmentProperties
+    ) -> Callable:
+        def _update_segment_color(*_args) -> None:
             for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_segment_color(seg_logic._id, segment_id, color)
+                modified = view.volume_handler.update_segment_color(
+                    seg_logic._id, segment_properties.value, segment_properties.display
+                )
                 if modified:
                     view.update()
 
         return _update_segment_color
 
-    def update_segment_visibility(self, seg_logic: SegmentationFilterLogic, segment_id: int):
-        def _update_segment_visbility(visible: bool) -> None:
-            if not seg_logic.is_visible:
-                return
+    def update_segment_visibility(self, seg_logic: SegmentationFilterLogic, segment_properties: SegmentProperties):
+        def _update_segment_visibility(*_args) -> None:
             for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_segment_visibility(seg_logic._id, segment_id, visible)
+                modified = view.volume_handler.update_segment_visibility(
+                    seg_logic._id, segment_properties.value, segment_properties.display
+                )
                 if modified:
                     view.update()
 
-        return _update_segment_visbility
+        return _update_segment_visibility
 
 
 class SegmentationHandler(ObjectHandler):
@@ -134,9 +134,9 @@ class SegmentationHandler(ObjectHandler):
 
     def add_segment_to_labelmap(self, seg_filter_logic: SegmentationFilterLogic) -> None:
         new_segment = seg_filter_logic.create_segment()
-        new_segment.watch(("color",), self._display_handler.update_segment_color(seg_filter_logic, new_segment.value))
+        new_segment.watch(("color",), self._display_handler.update_segment_color(seg_filter_logic, new_segment))
         new_segment.watch(
-            ("is_visible",), self._display_handler.update_segment_visibility(seg_filter_logic, new_segment.value)
+            ("is_visible",), self._display_handler.update_segment_visibility(seg_filter_logic, new_segment)
         )
         self.select_segment_in_labelmap(seg_filter_logic)
 

--- a/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
@@ -169,6 +169,9 @@ class VolumeHandler(ObjectHandler):
             self._add_to_primary_volumes(volume_logic._id)
             self._set_active_primary_volume_id(volume_logic._id)
 
+        elif layer == VolumeLayer.SECONDARY:
+            volume_logic.display.opacity = 0.5
+
         volume_logic.display.is_visible = True
 
         self.views_logic.add_volume(

--- a/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
@@ -138,10 +138,6 @@ class VolumeHandler(ObjectHandler):
                 self._display_handler.update_visibility(old_active, False)
 
         self.data.active_primary_volume_id = volume_id
-        if self.active_primary_volume_id is not None:
-            new_active = self.object_logics.get(self.active_primary_volume_id)
-            if not new_active.is_visible:
-                self._display_handler.update_visibility(new_active, True)
 
     def _add_to_primary_volumes(self, volume_id: str) -> None:
         if not self._is_primary_volume(volume_id):
@@ -173,6 +169,8 @@ class VolumeHandler(ObjectHandler):
             self._add_to_primary_volumes(volume_logic._id)
             self._set_active_primary_volume_id(volume_logic._id)
 
+        volume_logic.display.is_visible = True
+
         self.views_logic.add_volume(
             volume_logic._id,
             volume_logic.object_data,
@@ -190,26 +188,26 @@ class VolumeHandler(ObjectHandler):
         self._remove_from_primary_volumes(volume_logic._id)
         self._add_volume_to_views(volume_logic, VolumeLayer.SECONDARY)
 
-    def _get_next_volume(self, volume_logic: VolumeObjectLogic) -> tuple[str, bool]:
+    def _get_next_volume(self, volume_logic: VolumeObjectLogic) -> str:
         next_volume_id = volume_logic.input_id or volume_logic.soft_input_id
 
         if self._is_primary_volume(next_volume_id):
-            return next_volume_id, True  # primary parent
+            return next_volume_id  # primary parent
 
         for vol_id, vol in self.object_logics.items():
             if vol.soft_input_id == volume_logic._id:
                 if self._is_primary_volume(vol._id):
-                    return vol_id, True  # primary child
+                    return vol_id  # primary child
                 if next_volume_id is None:
                     next_volume_id = vol_id
 
         if len(self.primary_volume_ids) > 0:
-            return self.primary_volume_ids[0], True  # any primary volume
+            return self.primary_volume_ids[0]  # any primary volume
 
         if next_volume_id is not None:
-            return next_volume_id, False  # parent or child
+            return next_volume_id  # parent or child
 
-        return next(iter(self.object_logics), None), False  # any volume or None
+        return next(iter(self.object_logics), None)  # any volume or None
 
     def add_object_to_views(self, volume_logic: VolumeObjectLogic) -> None:
         self.object_logics[volume_logic._id] = volume_logic
@@ -239,9 +237,9 @@ class VolumeHandler(ObjectHandler):
         self.unregister_object_from_views(volume_logic)
 
         if self._is_active_volume(volume_logic._id):
-            next_volume_id, is_next_volume_primary = self._get_next_volume(volume_logic)
-            if is_next_volume_primary or next_volume_id is None:
-                self._set_active_primary_volume_id(next_volume_id)
+            next_volume_id = self._get_next_volume(volume_logic)
+            if next_volume_id is None:
+                self._set_active_primary_volume_id(None)
             else:
                 next_volume_logic = self.object_logics.get(next_volume_id)
                 self._reload_as_primary_volume(next_volume_logic)

--- a/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/scene/handlers/volume_handler.py
@@ -15,50 +15,36 @@ class VolumeDisplayHandler:
     def __init__(self, views_logic: ViewsLogic):
         self.views_logic = views_logic
 
-    def update_visibility(self, volume_logic: VolumeObjectLogic, visible: bool) -> None:
+    def set_visibility(self, volume_logic: VolumeObjectLogic, visible: bool) -> None:
         volume_logic.display.is_visible = visible
         for view in self.views_logic.views:
-            modified = view.volume_handler.set_volume_visibility(volume_logic._id, visible)
+            modified = view.volume_handler.update_volume_visibility(volume_logic._id, volume_logic.display)
             if modified:
                 view.update()
 
     def update_opacity(self, volume_logic: VolumeObjectLogic) -> Callable:
         @debounce(0.05)
-        def _update_opacity(opacity: float) -> None:
-            if opacity < 0 or not volume_logic.is_visible:
-                return
+        def _update_opacity(*_args) -> None:
             for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_volume_opacity(volume_logic._id, opacity)
+                modified = view.volume_handler.update_volume_opacity(volume_logic._id, volume_logic.display)
                 if modified:
                     view.update()
 
         return _update_opacity
 
     def update_threed_coloring(self, volume_logic: VolumeObjectLogic) -> Callable:
-        def _update_threed_coloring(threed_preset_name: str, threed_preset_vr_shift: list[float]) -> None:
-            if not volume_logic.is_visible:
-                return
+        def _update_threed_coloring(*_args) -> None:
             for view in self.views_logic.threed_views:
-                modified = view.volume_handler.set_volume_preset(
-                    volume_logic._id,
-                    threed_preset_name,
-                    threed_preset_vr_shift,
-                )
+                modified = view.volume_handler.update_volume_preset(volume_logic._id, volume_logic.display)
                 if modified:
                     view.update()
 
         return _update_threed_coloring
 
     def update_twod_coloring(self, volume_logic: VolumeObjectLogic) -> Callable:
-        def _update_twod_coloring(twod_preset_name: str, twod_preset_is_inverted: bool) -> None:
-            if not volume_logic.is_visible:
-                return
+        def _update_twod_coloring(*_args) -> None:
             for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_volume_scalar_color_preset(
-                    volume_logic._id,
-                    twod_preset_name,
-                    twod_preset_is_inverted,
-                )
+                modified = view.volume_handler.update_volume_scalar_color_preset(volume_logic._id, volume_logic.display)
                 if modified:
                     view.update()
 
@@ -66,19 +52,9 @@ class VolumeDisplayHandler:
 
     def update_normal_coloring(self, volume_logic: VolumeObjectLogic) -> Callable:
         @debounce(0.05)
-        def _update_normal_coloring(show_arrows: bool, sampling: int, arrow_length: float, arrow_width: float) -> None:
-            if not volume_logic.is_visible:
-                return
-
+        def _update_normal_coloring(*_args) -> None:
             for view in self.views_logic.views:
-                view.volume_handler.set_volume_visibility(volume_logic._id, not show_arrows)
-                modified = view.volume_handler.set_volume_normal_color(
-                    volume_logic._id,
-                    show_arrows,
-                    sampling,
-                    arrow_length,
-                    arrow_width,
-                )
+                modified = view.volume_handler.update_volume_normal_color(volume_logic._id, volume_logic.display)
                 if modified:
                     view.update()
 
@@ -86,11 +62,9 @@ class VolumeDisplayHandler:
 
     def update_window_level(self, volume_logic: VolumeObjectLogic) -> Callable:
         @debounce(0.05)
-        def _update_window_level(window_level: list[float]) -> None:
-            if not volume_logic.is_visible:
-                return
+        def _update_window_level(*_args) -> None:
             for view in self.views_logic.slice_views:
-                modified = view.volume_handler.set_volume_window_level_min_max(volume_logic._id, window_level)
+                modified = view.volume_handler.update_volume_window_level(volume_logic._id, volume_logic.display)
                 if modified:
                     view.update()
 
@@ -135,7 +109,7 @@ class VolumeHandler(ObjectHandler):
         if self.active_primary_volume_id is not None:
             old_active = self.object_logics.get(self.active_primary_volume_id)
             if old_active is not None and old_active.is_visible:
-                self._display_handler.update_visibility(old_active, False)
+                self._display_handler.set_visibility(old_active, False)
 
         self.data.active_primary_volume_id = volume_id
 
@@ -168,9 +142,6 @@ class VolumeHandler(ObjectHandler):
         if layer == VolumeLayer.PRIMARY:
             self._add_to_primary_volumes(volume_logic._id)
             self._set_active_primary_volume_id(volume_logic._id)
-
-        elif layer == VolumeLayer.SECONDARY:
-            volume_logic.display.opacity = 0.5
 
         volume_logic.display.is_visible = True
 
@@ -263,4 +234,4 @@ class VolumeHandler(ObjectHandler):
         if self._is_primary_volume(volume_logic._id) and not self._is_active_volume(volume_logic._id) and visible:
             self._reload_as_primary_volume(volume_logic)
         else:
-            self._display_handler.update_visibility(volume_logic, visible)
+            self._display_handler.set_visibility(volume_logic, visible)

--- a/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
@@ -44,10 +44,7 @@ class BaseVolumeObjectLogic(SceneObjectLogic):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.scene_object.object_type = SceneObjectType.VOLUME
-        self.display = VolumeDisplay(
-            self.server,
-            opacity=0.5,  # Used only for secondary volumes
-        )
+        self.display = VolumeDisplay(self.server)
         self.scene_object.display = self.display._id
         self.scene_object.flush()
 

--- a/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
+++ b/girdermedviewer/app/widgets/logic/scene/objects/volume_object_logic.py
@@ -44,7 +44,7 @@ class BaseVolumeObjectLogic(SceneObjectLogic):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.scene_object.object_type = SceneObjectType.VOLUME
-        self.display = VolumeDisplay(self.server)
+        self.display = VolumeDisplay(self.server, opacity=0.5) # Used only for secondary volumes
         self.scene_object.display = self.display._id
         self.scene_object.flush()
 

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
@@ -1,7 +1,7 @@
 import logging
 
 from trame_dataclass.v2 import get_instance
-from vtkmodules.vtkCommonDataModel import vtkPolyData
+from vtk import vtkPolyData, vtkRenderer
 
 from ....utils import (
     ColorPresetParser,
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 class MeshHandler(ObjectHandler):
-    def __init__(self, preset_parser: ColorPresetParser) -> None:
-        super().__init__()
+    def __init__(self, preset_parser: ColorPresetParser, renderer: vtkRenderer) -> None:
+        super().__init__(renderer)
         self.preset_parser = preset_parser
 
     def apply_mesh_display_properties(self, data_id: str, display_properties: MeshDisplay) -> None:

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/mesh_handler.py
@@ -25,29 +25,21 @@ class MeshHandler(ObjectHandler):
         super().__init__(renderer)
         self.preset_parser = preset_parser
 
-    def apply_mesh_display_properties(self, data_id: str, display_properties: MeshDisplay) -> None:
-        self.register_display(data_id, display_properties)
-
+    def apply_data_display(self, data_id: str, data_display: MeshDisplay) -> None:
         # Set opacity
-        self.set_mesh_opacity(data_id, display_properties.opacity)
+        self.update_mesh_opacity(data_id, data_display)
 
         # Set color
-        active_array = get_instance(display_properties.active_array_id)
+        active_array = get_instance(data_display.active_array_id)
         assert isinstance(active_array, DataArray)
         if active_array.coloring_mode == MeshColoringMode.SOLID:
-            self.set_mesh_solid_color(data_id, display_properties.solid_color)
+            self.update_mesh_solid_color(data_id, data_display)
 
         elif active_array.coloring_mode == MeshColoringMode.ARRAY:
-            self.set_mesh_array_color(
-                data_id,
-                active_array,
-                display_properties.array_color.name,
-                display_properties.array_color.is_inverted,
-                display_properties.array_color.array_range,
-            )
+            self.update_mesh_array_color(data_id, data_display, active_array)
 
         # Set visibility
-        self.set_mesh_visibility(data_id, display_properties.is_visible)
+        self.update_mesh_visibility(data_id, data_display)
 
     def add_mesh_in_3D(self, data_id: str, poly_data: vtkPolyData) -> None:
         actor = render_mesh_in_3D(poly_data, self.renderer)
@@ -57,40 +49,48 @@ class MeshHandler(ObjectHandler):
         actor = render_mesh_in_slice(poly_data, orientation, self.renderer)
         self.register_data(data_id, actor)
 
-    def set_mesh_visibility(self, data_id: str, visible: bool) -> bool:
+    def update_mesh_visibility(self, data_id: str, data_display: MeshDisplay) -> bool:
+        logger.debug(f"set_mesh_visibility({data_id}): {data_display.is_visible}")
         modified = False
         for actor in self.get_actors(data_id):
-            modified = set_mesh_visibility(actor, visible) or modified
+            modified = set_mesh_visibility(actor, data_display.is_visible) or modified
         return modified
 
-    def set_mesh_opacity(self, data_id: str, opacity: float) -> bool:
+    def update_mesh_opacity(self, data_id: str, data_display: MeshDisplay) -> bool:
+        logger.debug(f"set_mesh_opacity({data_id}): {data_display.opacity}")
         modified = False
         for actor in self.get_actors(data_id):
-            modified = set_mesh_opacity(actor, opacity) or modified
+            modified = set_mesh_opacity(actor, data_display.opacity) or modified
         return modified
 
-    def set_mesh_solid_color(self, data_id: str, color: str) -> bool:
-        color_tuple = convert_color_hex_to_normalized_rgb(color)
+    def update_mesh_solid_color(self, data_id: str, data_display: MeshDisplay) -> bool:
+        color_tuple = convert_color_hex_to_normalized_rgb(data_display.solid_color)
+        logger.debug(f"set_mesh_solid_color({data_id}): {color_tuple}")
         modified = False
         for actor in self.get_actors(data_id):
             modified = set_mesh_solid_color(actor, color_tuple) or modified
         return modified
 
-    def set_mesh_array_color(
-        self, data_id: str, array_obj: DataArray, preset_name: str, is_inverted: bool, preset_range: list[float]
-    ) -> bool:
-        if self.preset_parser is None:
-            return False
+    def update_mesh_array_color(self, data_id: str, data_display: MeshDisplay) -> bool:
+        array_color = data_display.array_color
+        active_array = get_instance(data_display.active_array_id)
 
-        logger.debug(f"set_mesh_array_color({data_id}): {preset_name}")
-        preset = self.preset_parser.get_preset_by_name(preset_name)
+        logger.debug(f"set_mesh_array_color({data_id}): {array_color.name}")
+        preset = self.preset_parser.get_preset_by_name(array_color.name)
         if preset is None:
             return False
 
         modified = False
         for actor in self.get_actors(data_id):
             modified = (
-                self.preset_parser.apply_preset_to_mesh(actor, array_obj, preset, preset_range, is_inverted) or modified
+                self.preset_parser.apply_preset_to_mesh(
+                    actor,
+                    active_array,
+                    preset,
+                    array_color.array_range,
+                    array_color.is_inverted,
+                )
+                or modified
             )
         return modified
 

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
@@ -17,13 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 class ObjectHandler:
-    def __init__(self) -> None:
+    def __init__(self, renderer: vtkRenderer) -> None:
         self.object_data = defaultdict(list)
         self.object_display = defaultdict(list)
-        self.renderer: vtkRenderer | None = None
-        self.roi_id: str | None = None
-
-    def set_renderer(self, renderer: vtkRenderer) -> None:
         self.renderer = renderer
 
     def register_data(self, data_id: str, data: Any) -> None:

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/object_handler.py
@@ -4,10 +4,6 @@ from typing import Any
 
 from vtkmodules.vtkRenderingCore import vtkRenderer
 
-from girdermedviewer.app.widgets.logic.scene.objects.scene_object_logic import (
-    SceneObjectDisplay,
-)
-
 from ....utils import (
     get_image_data,
     remove_prop,
@@ -19,14 +15,10 @@ logger = logging.getLogger(__name__)
 class ObjectHandler:
     def __init__(self, renderer: vtkRenderer) -> None:
         self.object_data = defaultdict(list)
-        self.object_display = defaultdict(list)
         self.renderer = renderer
 
     def register_data(self, data_id: str, data: Any) -> None:
         self.object_data[data_id].append(data)
-
-    def register_display(self, data_id: str, display: SceneObjectDisplay) -> None:
-        self.object_display[data_id] = display
 
     def unregister_data(self, data_id, only_data=None, remove=True):
         objects = self.object_data.get(data_id)
@@ -42,14 +34,10 @@ class ObjectHandler:
 
         if not self.object_data[data_id]:
             self.object_data.pop(data_id)
-            self.object_display.pop(data_id)
 
     def get_data(self, data_id):
         data = self.object_data.get(data_id, [])
         return data[0] if len(data) else None
-
-    def get_display(self, data_id: str) -> SceneObjectDisplay:
-        return self.object_display.get(data_id)
 
     def get_actors(self, data_id):
         data = [self.object_data[data_id]] if data_id in self.object_data else self.object_data.values()

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -5,6 +5,7 @@ from typing import Any
 from vtk import (
     vtkImageData,
     vtkImageSlice,
+    vtkRenderer,
     vtkResliceImageViewer,
 )
 
@@ -39,8 +40,8 @@ logger = logging.getLogger(__name__)
 
 
 class VolumeHandler(ObjectHandler, ABC):
-    def __init__(self, preset_parser: PresetParser):
-        super().__init__()
+    def __init__(self, preset_parser: PresetParser, renderer: vtkRenderer):
+        super().__init__(renderer)
         self.preset_parser = preset_parser
 
     @abstractmethod
@@ -60,8 +61,8 @@ class VolumeHandler(ObjectHandler, ABC):
 
 
 class VolumeSliceHandler(VolumeHandler):
-    def __init__(self, preset_parser: ColorPresetParser, orientation: int) -> None:
-        super().__init__(preset_parser)
+    def __init__(self, preset_parser: ColorPresetParser, renderer: vtkRenderer, orientation: int) -> None:
+        super().__init__(preset_parser, renderer)
         self.orientation = orientation
 
     def _is_primary_volume(self, data_id: str) -> bool:
@@ -249,8 +250,8 @@ class VolumeSliceHandler(VolumeHandler):
 
 
 class VolumeThreeDHandler(VolumeHandler):
-    def __init__(self, preset_parser: VolumePresetParser) -> None:
-        super().__init__(preset_parser)
+    def __init__(self, preset_parser: VolumePresetParser, renderer: vtkRenderer) -> None:
+        super().__init__(preset_parser, renderer)
 
     def _init_glyph_actors(self, data_id: str) -> None:
         glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer)

--- a/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
+++ b/girdermedviewer/app/widgets/logic/vtk/handlers/volume_handler.py
@@ -21,7 +21,6 @@ from ....utils import (
     render_volume_in_slice,
     set_actor_opacity,
     set_actor_visibility,
-    set_reslice_opacity,
     set_reslice_visibility,
     set_reslice_window_level,
     set_slice_opacity,
@@ -33,6 +32,7 @@ from ....utils import (
     set_volume_visibility,
 )
 from ....utils.vtk.segmentation import set_segment_color, set_segment_visibility
+from ...scene.filters.segmentation_filter_logic import SegmentDisplay
 from ...scene.objects.volume_object_logic import VolumeDisplay
 from .object_handler import ObjectHandler
 
@@ -45,18 +45,11 @@ class VolumeHandler(ObjectHandler, ABC):
         self.preset_parser = preset_parser
 
     @abstractmethod
-    def set_volume_visibility(self, data_id: str, visible: bool) -> bool:
+    def update_volume_visibility(self, data_id: str, data_display: VolumeDisplay) -> bool:
         pass
 
     @abstractmethod
-    def set_volume_normal_color(
-        self,
-        data_id: str,
-        show_arrows: bool,
-        sampling: int,
-        arrow_length: float,
-        arrow_width: float,
-    ) -> bool:
+    def update_volume_normal_color(self, data_id: str, data_display: VolumeDisplay) -> bool:
         pass
 
 
@@ -91,38 +84,19 @@ class VolumeSliceHandler(VolumeHandler):
         remove_prop = not (self._is_primary_volume(data_id) and self._has_multiple_primary_volumes())
         super().unregister_data(data_id, only_data, remove_prop)
 
-    def apply_volume_display_properties(
-        self, data_id: str, display_properties: VolumeDisplay, is_primary: bool
-    ) -> None:
-        self.register_display(data_id, display_properties)
-        self.set_volume_window_level_min_max(data_id, display_properties.window_level)
+    def apply_data_display(self, data_id: str, data_display: VolumeDisplay) -> None:
+        self.update_volume_window_level(data_id, data_display)
 
-        # Set opacity
-        if not is_primary:
-            self.set_volume_opacity(data_id, display_properties.opacity)
+        self.update_volume_opacity(data_id, data_display)
 
-        # Set color
-        else:
-            # FIXME: supposed to be set for secondary volumes also
-            self.set_volume_scalar_color_preset(
-                data_id,
-                display_properties.twod_color.name,
-                display_properties.twod_color.is_inverted,
-            )
+        self.update_volume_scalar_color_preset(data_id, data_display)
 
-        if display_properties.normal_color is not None:
+        if data_display.normal_color is not None:
             if not self.get_glyph_actors(data_id):
                 self._init_glyph_actors(data_id)
-            self.set_volume_normal_color(
-                data_id,
-                display_properties.normal_color.show_arrows,
-                display_properties.normal_color.sampling,
-                display_properties.normal_color.arrow_length,
-                display_properties.normal_color.arrow_width,
-            )
-
-        # Set visibility
-        self.set_volume_visibility(data_id, display_properties.is_visible)
+            self.update_volume_normal_color(data_id, data_display)
+        else:
+            self.update_volume_visibility(data_id, data_display)
 
     def add_primary_volume(self, data_id: str, image_data: vtkImageData) -> None:
         reslice_image_viewer = render_volume_in_slice(image_data, self.renderer, self.orientation)
@@ -136,37 +110,41 @@ class VolumeSliceHandler(VolumeHandler):
         actor = render_labelmap_as_overlay_in_slice(image_data, axis=self.orientation)
         self.register_data(data_id, actor)
 
-    def set_volume_visibility(self, data_id: str, visible: bool) -> bool:
-        logger.debug(f"set_volume_visibility({data_id}): {visible}")
-        volume_display = self.get_display(data_id)
-        if volume_display is None:
+    def update_volume_visibility(self, data_id: str, data_display: VolumeDisplay) -> bool:
+        logger.debug(f"set_volume_visibility({data_id}): {data_display.is_visible}")
+        normal_color = data_display.normal_color
+        show_arrows = data_display.is_visible and normal_color is not None and normal_color.show_arrows
+        show_volume = data_display.is_visible and not show_arrows
+
+        modified = False
+        reslice_image_viewer = self.get_reslice_image_viewer(data_id)
+        if reslice_image_viewer is not None:
+            modified = set_reslice_visibility(reslice_image_viewer, show_volume)
+        for slice in self.get_image_slices(data_id):
+            modified = set_slice_visibility(slice, show_volume) or modified
+        for glyph_actor in self.get_glyph_actors(data_id):
+            modified = set_actor_visibility(glyph_actor, show_arrows) or modified
+
+        return modified
+
+    def update_volume_opacity(self, data_id: str, data_display: VolumeDisplay) -> bool:
+        logger.debug(f"set_volume_opacity({data_id}): {data_display.opacity}")
+        modified = False
+        # Do not set opacity for reslice image viewer
+        for slice in self.get_image_slices(data_id):
+            modified = set_slice_opacity(slice, data_display.opacity) or modified
+        for glyph_actor in self.get_glyph_actors(data_id):
+            modified = set_actor_opacity(glyph_actor, data_display.opacity) or modified
+        return modified
+
+    def update_volume_window_level(self, data_id: str, data_display: VolumeDisplay) -> bool:
+        if not data_display.window_level:
             return False
-        show_arrows = volume_display.normal_color is not None and volume_display.normal_color.show_arrows
+        window_level = (
+            data_display.window_level[1] - data_display.window_level[0],
+            (data_display.window_level[0] + data_display.window_level[1]) / 2,
+        )
 
-        modified = False
-        reslice_image_viewer = self.get_reslice_image_viewer(data_id)
-        if reslice_image_viewer is not None:
-            modified = set_reslice_visibility(reslice_image_viewer, visible and not show_arrows)
-        for slice in self.get_image_slices(data_id):
-            modified = set_slice_visibility(slice, visible and not show_arrows) or modified
-        for glyph_actor in self.get_glyph_actors(data_id):
-            modified = set_actor_visibility(glyph_actor, visible and show_arrows) or modified
-
-        return modified
-
-    def set_volume_opacity(self, data_id: str, opacity: float) -> bool:
-        logger.debug(f"set_volume_opacity({data_id}): {opacity}")
-        modified = False
-        reslice_image_viewer = self.get_reslice_image_viewer(data_id)
-        if reslice_image_viewer is not None:
-            modified = set_reslice_opacity(reslice_image_viewer, opacity)
-        for slice in self.get_image_slices(data_id):
-            modified = set_slice_opacity(slice, opacity) or modified
-        for glyph_actor in self.get_glyph_actors(data_id):
-            modified = set_actor_opacity(glyph_actor, opacity) or modified
-        return modified
-
-    def set_volume_window_level(self, data_id: str, window_level: tuple[float]) -> bool:
         logger.debug(f"set_volume_window_level({data_id}): {window_level}")
         modified = False
         reslice_image_viewer = self.get_reslice_image_viewer(data_id)
@@ -176,49 +154,38 @@ class VolumeSliceHandler(VolumeHandler):
             modified = set_slice_window_level(slice, window_level) or modified
         return modified
 
-    def set_volume_window_level_min_max(self, data_id: str, window_level_min_max: list[float]) -> bool:
-        """
-        :see-also set_volume_window_level
-        """
-        if window_level_min_max is not None:
-            window = window_level_min_max[1] - window_level_min_max[0]
-            level = (window_level_min_max[0] + window_level_min_max[1]) / 2
-            return self.set_volume_window_level(data_id, (window, level))
-        return False
+    def update_volume_scalar_color_preset(self, data_id: str, data_display: VolumeDisplay) -> bool:
+        twod_color = data_display.twod_color
+        volume = self.get_data(data_id)
+        if volume is None or twod_color is None:
+            return False
 
-    def set_volume_scalar_color_preset(self, data_id: str, preset_name: str, is_inverted: bool) -> bool:
-        logger.debug(f"set_volume_scalar_color_preset({data_id}):{' Inverse' if is_inverted else ''} {preset_name}")
-        preset = self.preset_parser.get_preset_by_name(preset_name)
+        logger.debug(
+            f"set_volume_scalar_color_preset({data_id}):{' Inverse' if twod_color.is_inverted else ''} {twod_color.name}"
+        )
+        preset = self.preset_parser.get_preset_by_name(twod_color.name)
         if preset is None:
             return False
 
         modified = False
         reslice_image_viewer = self.get_reslice_image_viewer(data_id)
         if reslice_image_viewer is not None or preset is None:
-            modified = self.preset_parser.apply_preset_to_volume(reslice_image_viewer, preset, is_inverted)
+            modified = self.preset_parser.apply_preset_to_volume(reslice_image_viewer, preset, twod_color.is_inverted)
         for slice in self.get_image_slices(data_id):
-            modified = self.preset_parser.apply_preset_to_volume(slice.GetProperty(), preset, is_inverted)
+            modified = self.preset_parser.apply_preset_to_volume(slice.GetProperty(), preset, twod_color.is_inverted)
         return modified
 
-    def set_volume_normal_color(
-        self,
-        data_id: str,
-        show_arrows: bool,
-        sampling: int,
-        arrow_length: float,
-        arrow_width: float,
-    ) -> bool:
-        volume_display = self.get_display(data_id)
-        if volume_display is None:
+    def update_volume_normal_color(self, data_id: str, data_display: VolumeDisplay) -> bool:
+        normal_color = data_display.normal_color
+        if normal_color is None:
             return False
 
         logger.debug(f"set_volume_normal_color({data_id})")
-        modified = False
+        modified = self.update_volume_visibility(data_id, data_display)
         for glyph_actor in self.get_glyph_actors(data_id):
-            modified = set_actor_visibility(glyph_actor, show_arrows and volume_display.is_visible) or modified
-            modified = set_vector_field_sampling(glyph_actor, sampling, self.orientation) or modified
-            modified = set_vector_field_arrow_length(glyph_actor, arrow_length) or modified
-            modified = set_vector_field_arrow_thickness(glyph_actor, arrow_width) or modified
+            modified = set_vector_field_sampling(glyph_actor, normal_color.sampling, self.orientation) or modified
+            modified = set_vector_field_arrow_length(glyph_actor, normal_color.arrow_length) or modified
+            modified = set_vector_field_arrow_thickness(glyph_actor, normal_color.arrow_width) or modified
 
         return modified
 
@@ -235,17 +202,17 @@ class VolumeSliceHandler(VolumeHandler):
         ids = [data_id] if data_id in self.object_data else self.object_data.keys()
         return [self.get_data(id) for id in ids if self._is_secondary_volume(id)]
 
-    def set_segment_color(self, data_id: str, segment_id: int, color: str) -> bool:
-        color_tuple = convert_color_hex_to_normalized_rgb(color)
+    def update_segment_color(self, data_id: str, segment_id: int, segment_display: SegmentDisplay) -> bool:
+        color_tuple = convert_color_hex_to_normalized_rgb(segment_display.color)
         modified = False
         for image_slice in self.get_image_slices(data_id):
             modified = set_segment_color(image_slice, segment_id, color_tuple) or modified
         return modified
 
-    def set_segment_visibility(self, data_id: str, segment_id: int, visible: bool) -> bool:
+    def update_segment_visibility(self, data_id: str, segment_id: int, segment_display: SegmentDisplay) -> bool:
         modified = False
         for image_slice in self.get_image_slices(data_id):
-            modified = set_segment_visibility(image_slice, segment_id, visible) or modified
+            modified = set_segment_visibility(image_slice, segment_id, segment_display.is_visible) or modified
         return modified
 
 
@@ -257,78 +224,55 @@ class VolumeThreeDHandler(VolumeHandler):
         glyph_actor = render_volume_as_vector_field(self.get_image_data(data_id), self.renderer)
         self.register_data(data_id, glyph_actor)
 
-    def apply_volume_display_properties(self, data_id: str, display_properties: VolumeDisplay) -> None:
-        self.register_display(data_id, display_properties)
-
-        # Set color
-        if display_properties.normal_color is not None:
-            if not self.get_glyph_actors(data_id):
-                self._init_glyph_actors(data_id)
-            self.set_volume_normal_color(
-                data_id,
-                display_properties.normal_color.show_arrows,
-                display_properties.normal_color.sampling,
-                display_properties.normal_color.arrow_length,
-                display_properties.normal_color.arrow_width,
-            )
-        else:
-            self.set_volume_preset(
-                data_id,
-                display_properties.threed_color.name,
-                display_properties.threed_color.vr_shift,
-            )
-
-        # Set visibility
-        self.set_volume_visibility(data_id, display_properties.is_visible)
-
     def add_volume(self, data_id: str, image_data: vtkImageData) -> None:
         volume = render_volume_in_3D(image_data, self.renderer)
         self.register_data(data_id, volume)
 
-    def set_volume_visibility(self, data_id: str, visible: bool) -> bool:
-        logger.debug(f"set_volume_visibility({data_id}): {visible}")
+    def apply_data_display(self, data_id: str, data_display: VolumeDisplay) -> None:
+        if data_display.normal_color is not None:
+            if not self.get_glyph_actors(data_id):
+                self._init_glyph_actors(data_id)
+            self.update_volume_normal_color(data_id, data_display)
+        else:
+            self.update_volume_preset(data_id, data_display)
+            self.update_volume_visibility(data_id, data_display)
+
+    def update_volume_visibility(self, data_id: str, data_display: VolumeDisplay) -> bool:
         volume = self.get_data(data_id)
         if volume is None:
             return False
 
-        volume_display = self.get_display(data_id)
-        if volume_display is None:
-            return False
-
-        modified = set_volume_visibility(volume, visible and volume_display.normal_color is None)
-        show_arrows = volume_display.normal_color is not None and volume_display.normal_color.show_arrows
+        logger.debug(f"set_volume_visibility({data_id}): {data_display.is_visible}")
+        modified = set_volume_visibility(volume, data_display.is_visible and data_display.normal_color is None)
+        show_arrows = (
+            data_display.is_visible and data_display.normal_color is not None and data_display.normal_color.show_arrows
+        )
         for glyph_actor in self.get_glyph_actors(data_id):
-            modified = set_actor_visibility(glyph_actor, visible and show_arrows) or modified
+            modified = set_actor_visibility(glyph_actor, show_arrows) or modified
         return modified
 
-    def set_volume_preset(self, data_id: str, preset_name: str, range: list[float]) -> bool:
+    def update_volume_preset(self, data_id: str, data_display: VolumeDisplay) -> bool:
+        threed_color = data_display.threed_color
         volume = self.get_data(data_id)
-        if volume is None:
+        if volume is None or threed_color is None:
             return False
-        logger.debug(f"set_volume_preset({data_id}): {preset_name}, {range}")
-        preset = self.preset_parser.get_preset_by_name(preset_name)
+
+        logger.debug(f"set_volume_preset({data_id}): {threed_color.name}, {threed_color.vr_shift}")
+        preset = self.preset_parser.get_preset_by_name(threed_color.name)
         if preset is None:
             return False
-        return self.preset_parser.apply_preset(volume.GetProperty(), preset, range)
+        return self.preset_parser.apply_preset(volume.GetProperty(), preset, threed_color.vr_shift)
 
-    def set_volume_normal_color(
-        self,
-        data_id: str,
-        show_arrows: bool,
-        sampling: int,
-        arrow_length: float,
-        arrow_width: float,
-    ) -> bool:
-        volume_display = self.get_display(data_id)
-        if volume_display is None:
+    def update_volume_normal_color(self, data_id: str, data_display: VolumeDisplay) -> bool:
+        normal_color = data_display.normal_color
+        if normal_color is None:
             return False
 
         logger.debug(f"set_volume_normal_color({data_id})")
-        modified = False
+        modified = self.update_volume_visibility(data_id, data_display)
         for glyph_actor in self.get_glyph_actors(data_id):
-            modified = set_actor_visibility(glyph_actor, show_arrows and volume_display.is_visible) or modified
-            modified = set_vector_field_sampling(glyph_actor, sampling) or modified
-            modified = set_vector_field_arrow_length(glyph_actor, arrow_length) or modified
-            modified = set_vector_field_arrow_thickness(glyph_actor, arrow_width) or modified
+            modified = set_vector_field_sampling(glyph_actor, normal_color.sampling) or modified
+            modified = set_vector_field_arrow_length(glyph_actor, normal_color.arrow_length) or modified
+            modified = set_vector_field_arrow_thickness(glyph_actor, normal_color.arrow_width) or modified
 
         return modified

--- a/girdermedviewer/app/widgets/logic/vtk/tools/place_roi_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/tools/place_roi_logic.py
@@ -37,6 +37,19 @@ class PlaceROILogic(BaseToolLogic[PlaceROIState]):
             }
         )
 
+        self._add_roi_to_views()
+
+    def _add_roi_to_views(self):
+        for view_logic in self._views_logic.threed_views:
+            self.box_widget.SetInteractor(view_logic.renderer.GetRenderWindow().GetInteractor())
+            self.box_widget.SetCurrentRenderer(view_logic.renderer)
+
+        for view_logic in self._views_logic.slice_views:
+            actor = render_mesh_in_slice(self.poly_data, view_logic.orientation.value, view_logic.renderer)
+            self.box_actors.append(actor)
+
+        self.set_enabled(False)
+
     def _get_bounds(self):
         return (
             self.data.min_roi_bounds.pos_x,
@@ -114,14 +127,3 @@ class PlaceROILogic(BaseToolLogic[PlaceROIState]):
 
     def set_ui(self, ui: PlaceROIUI) -> None:
         ui.reset_clicked.connect(self._reset)
-
-        for view_logic in self._views_logic.threed_views:
-            self.box_widget.SetInteractor(view_logic.renderer.GetRenderWindow().GetInteractor())
-            self.box_widget.SetCurrentRenderer(view_logic.renderer)
-
-        self.box_actors = []
-        for view_logic in self._views_logic.slice_views:
-            actor = render_mesh_in_slice(self.poly_data, view_logic.orientation.value, view_logic.renderer)
-            self.box_actors.append(actor)
-
-        self.set_enabled(False)

--- a/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
@@ -63,7 +63,7 @@ class SliceViewLogic(ViewLogic[VolumeSliceHandler]):
             }
         )
 
-        self.volume_handler = VolumeSliceHandler(self.color_preset_parser, self.orientation.value)
+        self.volume_handler = VolumeSliceHandler(self.color_preset_parser, self.renderer, self.orientation.value)
 
     @property
     def position(self) -> tuple[float]:

--- a/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/slice_view_logic.py
@@ -96,15 +96,13 @@ class SliceViewLogic(ViewLogic[VolumeSliceHandler]):
         self,
         data_id: str,
         image_data: vtkImageData,
-        display_properties: VolumeDisplay,
+        data_display: VolumeDisplay,
         layer: VolumeLayer,
         subtype: SceneObjectSubtype,
     ):
-        is_primary = False
         if subtype == SceneObjectSubtype.LABELMAP and layer == VolumeLayer.SECONDARY:
             self.volume_handler.add_labelmap(data_id, image_data)
         elif layer == VolumeLayer.PRIMARY:
-            is_primary = True
             self.volume_handler.add_primary_volume(data_id, image_data)
             self._set_reslice_interaction()
         elif layer == VolumeLayer.SECONDARY:
@@ -112,11 +110,11 @@ class SliceViewLogic(ViewLogic[VolumeSliceHandler]):
         else:
             raise ValueError("Volume layer cannot be undefined.")
 
-        self.volume_handler.apply_volume_display_properties(data_id, display_properties, is_primary)
+        self.volume_handler.apply_data_display(data_id, data_display)
 
-    def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: MeshDisplay) -> None:
+    def add_mesh(self, data_id: str, poly_data: vtkPolyData, data_display: MeshDisplay) -> None:
         self.mesh_handler.add_mesh_in_slice(data_id, poly_data, self.orientation.value)
-        self.mesh_handler.apply_mesh_display_properties(data_id, display_properties)
+        self.mesh_handler.apply_data_display(data_id, data_display)
 
     def flush(self) -> None:
         if SliceViewLogic.DEBOUNCED_FLUSH:

--- a/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class ThreeDViewLogic(ViewLogic[VolumeThreeDHandler]):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self.volume_handler = VolumeThreeDHandler(self.volume_preset_parser)
+        self.volume_handler = VolumeThreeDHandler(self.volume_preset_parser, self.renderer)
 
     def add_volume(
         self,

--- a/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/threed_view_logic.py
@@ -24,18 +24,18 @@ class ThreeDViewLogic(ViewLogic[VolumeThreeDHandler]):
         self,
         data_id: str,
         image_data: vtkImageData,
-        display_properties: VolumeDisplay,
+        data_display: VolumeDisplay,
         layer: VolumeLayer,
         subtype: SceneObjectSubtype,
     ) -> None:
         if subtype == SceneObjectSubtype.LABELMAP and layer == VolumeLayer.SECONDARY:
             return
         self.volume_handler.add_volume(data_id, image_data)
-        self.volume_handler.apply_volume_display_properties(data_id, display_properties)
+        self.volume_handler.apply_data_display(data_id, data_display)
 
-    def add_mesh(self, data_id: str, poly_data: vtkPolyData, display_properties: MeshDisplay) -> None:
+    def add_mesh(self, data_id: str, poly_data: vtkPolyData, data_display: MeshDisplay) -> None:
         self.mesh_handler.add_mesh_in_3D(data_id, poly_data)
-        self.mesh_handler.apply_mesh_display_properties(data_id, display_properties)
+        self.mesh_handler.apply_data_display(data_id, data_display)
 
     def reset(self) -> None:
         reset_3D(self.renderer)

--- a/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views/view_logic.py
@@ -13,6 +13,7 @@ from ....utils import (
     SceneObjectSubtype,
     VolumeLayer,
     VolumePresetParser,
+    create_rendering_pipeline,
 )
 from ...base_logic import BaseLogic
 from ...scene.objects.mesh_object_logic import MeshDisplay
@@ -37,18 +38,16 @@ class ViewLogic(BaseLogic[ViewState], Generic[T], ABC):
         color_preset_parser: ColorPresetParser,
     ) -> None:
         super().__init__(server, ViewState, view_type.value)
+        self.renderer, self.render_window = create_rendering_pipeline()
         self.type = view_type
         self.volume_preset_parser = volume_preset_parser
         self.color_preset_parser = color_preset_parser
 
-        self.mesh_handler = MeshHandler(color_preset_parser)
+        self.mesh_handler = MeshHandler(color_preset_parser, self.renderer)
 
         self._views_state = TypedState(self.state, ViewsState)
 
     def set_ui(self, ui: ViewUI) -> None:
-        self.renderer = ui.renderer
-        self.mesh_handler.set_renderer(ui.renderer)
-        self.volume_handler.set_renderer(ui.renderer)
         self.update = ui.update
 
     @abstractmethod

--- a/girdermedviewer/app/widgets/logic/vtk/views_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views_logic.py
@@ -44,6 +44,10 @@ class ViewsLogic(BaseLogic[ViewsState]):
             self.view_logics[view_type].window_level_changed.connect(self.window_level_changed)
 
     @property
+    def render_windows(self):
+        return {view_type: view.render_window for view_type, view in self.view_logics.items()}
+
+    @property
     def views(self) -> list[ViewLogic[VolumeHandler]]:
         return list(self.view_logics.values())
 

--- a/girdermedviewer/app/widgets/logic/vtk/views_logic.py
+++ b/girdermedviewer/app/widgets/logic/vtk/views_logic.py
@@ -2,9 +2,7 @@ from typing import Any
 
 from trame_server.core import Server
 from undo_stack import Signal
-from vtk import vtkImageData, vtkPolyData
-
-from girdermedviewer.app.widgets.logic.vtk.handlers.volume_handler import VolumeHandler
+from vtk import vtkImageData, vtkPolyData, vtkRenderWindow
 
 from ...logic.base_logic import BaseLogic
 from ...ui import ViewsState, ViewsUI, ViewType
@@ -15,6 +13,7 @@ from ...utils import (
     get_volume_preset_parser,
 )
 from ..scene.objects.volume_object_logic import VolumeDisplay
+from .handlers.volume_handler import VolumeHandler
 from .views.slice_view_logic import SliceViewLogic
 from .views.threed_view_logic import ThreeDViewLogic
 from .views.view_logic import ViewLogic
@@ -44,7 +43,7 @@ class ViewsLogic(BaseLogic[ViewsState]):
             self.view_logics[view_type].window_level_changed.connect(self.window_level_changed)
 
     @property
-    def render_windows(self):
+    def render_windows(self) -> dict[ViewType, vtkRenderWindow]:
         return {view_type: view.render_window for view_type, view in self.view_logics.items()}
 
     @property

--- a/girdermedviewer/app/widgets/ui/app_ui.py
+++ b/girdermedviewer/app/widgets/ui/app_ui.py
@@ -5,13 +5,14 @@ from trame.widgets import gwc
 from trame.widgets import vuetify3 as v3
 from trame_server import Server
 from trame_server.utils.typed_state import TypedState
+from vtk import vtkRenderWindow
 
 from ..utils import AppConfig, GlobalStyle
 from .girder.girder_browser_ui import GirderBrowserUI
 from .girder.girder_connection_ui import GirderConnectionUI
 from .scene.scene_ui import SceneUI
 from .vtk.tool_ui import ToolUI
-from .vtk.views_ui import ViewsUI
+from .vtk.views_ui import ViewsUI, ViewType
 
 
 @dataclass
@@ -55,7 +56,13 @@ class AppLayout(VAppLayout):
 
 
 class AppUI:
-    def __init__(self, layout: AppLayout, provider: gwc.GirderProvider, app_config: AppConfig) -> None:
+    def __init__(
+        self,
+        layout: AppLayout,
+        provider: gwc.GirderProvider,
+        app_config: AppConfig,
+        render_windows: dict[ViewType, vtkRenderWindow],
+    ) -> None:
         self.layout = layout
         self.provider = provider
 
@@ -74,7 +81,7 @@ class AppUI:
                 self.tool_ui = ToolUI()
 
             with self.layout.viewer:
-                self.views_ui = ViewsUI()
+                self.views_ui = ViewsUI(render_windows)
 
             with self.layout.drawer:
                 self.scene_ui = SceneUI()

--- a/girdermedviewer/app/widgets/ui/scene/filters/segmentation_filter_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/filters/segmentation_filter_ui.py
@@ -19,7 +19,7 @@ class SegmentColorDialog(v3.VDialog):
                 Text("Edit segment color")
                 Button(icon="mdi-close", size="small", click=f"{self._segment}.is_color_dialog_visible = false;")
             with v3.VCardText():
-                ColorPicker(v_model=(f"{self._segment}.color",))
+                ColorPicker(v_model=(f"{self._segment}.display.color",))
 
 
 class SegmentList(v3.VList):
@@ -54,7 +54,7 @@ class SegmentList(v3.VList):
                 v3.Template(v_slot_prepend=True),
                 Button(
                     icon="mdi-circle",
-                    color=("segment.color",),
+                    color=("segment.display.color",),
                     size="small",
                 ),
             ):
@@ -68,8 +68,8 @@ class SegmentList(v3.VList):
 
             with v3.Template(v_slot_append=True):
                 Button(
-                    icon=("segment.is_visible ? 'mdi-eye-outline' : 'mdi-eye-off-outline'",),
-                    click_stop="segment.is_visible = !segment.is_visible",
+                    icon=("segment.display.is_visible ? 'mdi-eye-outline' : 'mdi-eye-off-outline'",),
+                    click_stop="segment.display.is_visible = !segment.display.is_visible",
                     size="small",
                 )
                 Button(

--- a/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
+++ b/girdermedviewer/app/widgets/ui/scene/objects/object_display_ui.py
@@ -34,13 +34,12 @@ class VolumeDisplayUI(html.Div):
     def _build_ui(self) -> None:
         with self:
             with html.Div(v_if=(self._is_volume_subtype(SceneObjectSubtype.SCALAR),)):
-                with html.Div(v_if=(self.is_primary,)):
-                    VolumeDisplayThreeDColorUI(
-                        v_if=(f"{self.display}.threed_color",),
-                        obj_display=self.display,
-                        threed_presets=self.threed_presets,
-                    )
-                    v3.VDivider(classes="display-property-divider")
+                VolumeDisplayThreeDColorUI(
+                    v_if=(f"{self.display}.threed_color",),
+                    obj_display=self.display,
+                    threed_presets=self.threed_presets,
+                )
+                v3.VDivider(classes="display-property-divider")
                 VolumeDisplayTwoDColorUI(
                     v_if=(f"{self.display}.twod_color",), obj_display=self.display, twod_presets=self.twod_presets
                 )

--- a/girdermedviewer/app/widgets/ui/vtk/views_ui.py
+++ b/girdermedviewer/app/widgets/ui/vtk/views_ui.py
@@ -6,11 +6,9 @@ from trame.widgets import html, rca
 from trame.widgets import vuetify3 as v3
 from trame_server.utils.typed_state import TypedState
 from undo_stack import Signal
+from vtk import vtkRenderWindow
 
-from ...utils import (
-    Button,
-    create_rendering_pipeline,
-)
+from ...utils import Button
 from .tools.point_selector_ui import PointState
 
 logger = logging.getLogger(__name__)
@@ -64,21 +62,20 @@ class ViewSliderUI(v3.VSlider):
 
 
 class ViewUI(html.Div):
-    def __init__(self, view_type: ViewType, **kwargs):
+    def __init__(self, view_type: ViewType, render_window: vtkRenderWindow, **kwargs) -> None:
         super().__init__(**kwargs)
 
-        self.renderer, self.render_window = create_rendering_pipeline()
-
+        self.render_window = render_window
         self.type = view_type
         self._views_state = TypedState(self.state, ViewsState)
         self._typed_state = TypedState(self.state, ViewState, namespace=view_type.value)
 
         self._build_ui()
 
-    def update(self):
+    def update(self) -> None:
         self.view_handler.update()
 
-    def _build_ui(self):
+    def _build_ui(self) -> None:
         with self:
             my_rca = rca.RemoteControlledArea(
                 v_if=(f"!{self._views_state.name.is_viewer_disabled}",), display="image", send_mouse_move=True
@@ -105,25 +102,26 @@ class ViewUI(html.Div):
                         disabled=(self._views_state.name.is_viewer_disabled,),
                     )
 
-    def toggle_fullscreen(self):
+    def toggle_fullscreen(self) -> None:
         self._views_state.data.fullscreen = None if self._views_state.data.fullscreen else self.type
 
 
 class ViewsUI(v3.VContainer):
-    def __init__(self, **kwargs):
+    def __init__(self, render_windows: dict[ViewType, vtkRenderWindow], **kwargs) -> None:
         super().__init__(classes="fill-height pa-0", fluid=True, **kwargs)
         self._typed_state = TypedState(self.state, ViewsState)
         self.view_uis: dict[ViewType, ViewUI] = {}
 
-        self._build_quad_view()
+        self._build_quad_view(render_windows)
 
-    def _build_quad_view(self):
+    def _build_quad_view(self, render_windows: dict[ViewType, vtkRenderWindow]) -> None:
         with self, html.Div(classes="quad-view"):
             for view_type in [ViewType.SAGITTAL, ViewType.THREED, ViewType.CORONAL, ViewType.AXIAL]:
                 self.view_uis[view_type] = ViewUI(
                     v_if=(self._has_view(view_type),),
                     classes=(f"{self._has_fullscreen_view(view_type)} ? 'fullscreen-view' : 'view'",),
                     view_type=view_type,
+                    render_window=render_windows.get(view_type),
                 )
 
     def _has_fullscreen_view(self, view_type: ViewType) -> str:

--- a/girdermedviewer/app/widgets/utils/vtk/vtk_utils.py
+++ b/girdermedviewer/app/widgets/utils/vtk/vtk_utils.py
@@ -716,7 +716,7 @@ def remove_prop(renderer: vtkRenderer, prop: vtkProp | vtkResliceImageViewer):
         raise Exception(f"Can't remove prop {prop}")
 
 
-def create_rendering_pipeline():
+def create_rendering_pipeline() -> tuple[vtkRenderer, vtkRenderWindow]:
     renderer = vtkRenderer()
     render_window = vtkRenderWindow()
     render_window.ShowWindowOff()


### PR DESCRIPTION
- Addressed volume opacity: specifiy volume opacity for secondary volumes and labelmap
- Rendering pipeline is created in the logic and passed to the UI: Rendering pipeline was defined in the UI. However we need the renderer in the logic which implied to "wait" for the set_ui to be able to render anything which seemed a bit arbitrary. 
- Vtk handlers receive directly display objects and do not register them anymore